### PR TITLE
Email subscription

### DIFF
--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
@@ -5,6 +5,7 @@ import com.google.appengine.repackaged.org.joda.time.format.DateTimeFormat;
 import com.google.appengine.repackaged.org.joda.time.format.DateTimeFormatter;
 import com.google.common.base.Preconditions;
 import com.jasify.schedule.appengine.model.activity.Activity;
+import com.jasify.schedule.appengine.model.activity.ActivityType;
 import com.jasify.schedule.appengine.model.activity.Subscription;
 import com.jasify.schedule.appengine.model.common.Organization;
 import com.jasify.schedule.appengine.model.users.User;
@@ -14,17 +15,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * @author wszarmach
  * @since 14/02/15.
- * Temporary class to create html emails
+ * Temporary class to create html/text emails
  */
 public class MailParser {
 
     private static final DateTimeFormatter dtf = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm");
 
     private enum SubstituteKey {
+        ActivityDetails("%ActivityDetails%"),
         ActivityFinish("%ActivityFinish%"),
         ActivityName("%ActivityName%"),
         ActivityPrice("%ActivityPrice%"),
@@ -51,6 +57,19 @@ public class MailParser {
         }
     }
 
+    private enum MultiSubscription {
+        Jasify("/jasify/Subscription", "/jasify/SubscriptionActivityDetails"),
+        Subscriber("/subscriber/Subscription", "/subscriber/SubscriptionActivityDetails");
+
+        String subscription;
+        String activityDetails;
+
+        MultiSubscription(String subscription, String activityDetails) {
+            this.subscription = subscription;
+            this.activityDetails = activityDetails;
+        }
+    }
+
     public static MailParser createNewVersionEmail(String version, String timestamp, String branch, String number, String jasifyUrl) throws Exception {
         MailParser mailParser = new MailParser("/jasify/NewVersion");
         mailParser.substitute(SubstituteKey.Version, version);
@@ -63,70 +82,91 @@ public class MailParser {
 
     public static MailParser createJasifyUserSignUpEmail(User user) throws Exception {
         MailParser mailParser = new MailParser("/jasify/UserSignUp");
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
         mailParser.substitute(SubstituteKey.UserName, user.getName());
         return mailParser;
     }
 
-    public static MailParser createJasifySubscriptionEmail(Subscription subscription, Organization organization) throws Exception {
-        String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
-        User user = subscription.getUserRef().getModel();
+    private static MailParser createSubscriptionActivityDetails(MultiSubscription multiSubscription, Subscription subscription) throws IOException {
         Activity activity = subscription.getActivityRef().getModel();
-        BigDecimal bdActivityPrice = convert(activity.getPrice());
-        BigDecimal bdFees = convert(0.0);
-        BigDecimal bdTax = convert(0.0);
+        ActivityType activityType = activity.getActivityTypeRef().getModel();
+        Organization organization = activityType.getOrganizationRef().getModel();
+        String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
         DateTime start = new DateTime(activity.getStart());
         DateTime finish = new DateTime(activity.getFinish());
-        MailParser mailParser = new MailParser("/jasify/Subscription");
+        MailParser mailParser = new MailParser(multiSubscription.activityDetails);
         mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
         mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
         mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
         mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));
         mailParser.substitute(SubstituteKey.ActivityFinish, finish.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(bdActivityPrice));
-        mailParser.substitute(SubstituteKey.Fees, formatPrice(bdFees));
-        mailParser.substitute(SubstituteKey.Tax, formatPrice(bdTax));
-        BigDecimal bdTotalPrice = convert(bdActivityPrice.add(bdFees).add(bdTax).doubleValue());
-        mailParser.substitute(SubstituteKey.TotalPrice, formatPrice(bdTotalPrice));
+        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(activity.getPrice()));
+        return mailParser;
+    }
+
+    private static MailParser createSubscriptionEmail(MultiSubscription multiSubscription, List<Subscription> subscriptions) throws Exception {
+        double totalPrice = 0;
+        String subscriberName = null;
+        List<MailParser> activityDetails = new ArrayList<>();
+        for (Subscription subscription : subscriptions) {
+            if (subscription.getActivityRef().getModel().getPrice() != null) {
+                totalPrice += subscription.getActivityRef().getModel().getPrice();
+            }
+            activityDetails.add(MailParser.createSubscriptionActivityDetails(multiSubscription, subscription));
+            if (subscriberName == null) {
+                User user = subscription.getUserRef().getModel();
+                subscriberName = user.getDisplayName();
+            }
+        }
+
+        double fees = 0.0;
+        double tax = 0.0;
+        totalPrice = totalPrice + fees + tax;
+
+        MailParser mailParser = new MailParser(multiSubscription.subscription);
+        mailParser.substitute(SubstituteKey.SubscriberName, subscriberName);
+        mailParser.substitute(SubstituteKey.ActivityDetails, activityDetails);
+        mailParser.substitute(SubstituteKey.Fees, formatPrice(fees));
+        mailParser.substitute(SubstituteKey.Tax, formatPrice(tax));
+        mailParser.substitute(SubstituteKey.TotalPrice, formatPrice(totalPrice));
         mailParser.substitute(SubstituteKey.PaymentMethod, "Unknown");
         return mailParser;
     }
 
-    public static MailParser createPublisherSubscriptionEmail(Subscription subscription, Organization organization) throws Exception {
+    public static MailParser createJasifySubscriptionEmail(Subscription subscription) throws Exception {
+        return createJasifySubscriptionEmail(Arrays.asList(new Subscription[]{subscription}));
+    }
+
+    public static MailParser createJasifySubscriptionEmail(List<Subscription> subscriptions) throws Exception {
+        return createSubscriptionEmail(MultiSubscription.Jasify, subscriptions);
+    }
+
+    public static MailParser createPublisherSubscriptionEmail(Subscription subscription) throws Exception {
+        Activity activity = subscription.getActivityRef().getModel();
+        ActivityType activityType = activity.getActivityTypeRef().getModel();
+        Organization organization = activityType.getOrganizationRef().getModel();
+
         String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
         User user = subscription.getUserRef().getModel();
-        Activity activity = subscription.getActivityRef().getModel();
-        BigDecimal bdActivityPrice = convert(activity.getPrice());
         DateTime start = new DateTime(activity.getStart());
         DateTime finish = new DateTime(activity.getFinish());
         MailParser mailParser = new MailParser("/publisher/Subscription");
         mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
         mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
         mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
         mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));
         mailParser.substitute(SubstituteKey.ActivityFinish, finish.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(bdActivityPrice));
+        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(activity.getPrice()));
         return mailParser;
     }
 
-    public static MailParser createSubscriberSubscriptionEmail(Subscription subscription, Organization organization) throws Exception {
-        String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
-        User user = subscription.getUserRef().getModel();
-        Activity activity = subscription.getActivityRef().getModel();
-        BigDecimal bdActivityPrice = convert(activity.getPrice());
-        DateTime start = new DateTime(activity.getStart());
-        DateTime finish = new DateTime(activity.getFinish());
-        MailParser mailParser = new MailParser("/subscriber/Subscription");
-        mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
-        mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
-        mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
-        mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityFinish, finish.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(bdActivityPrice));
-        return mailParser;
+    public static MailParser createSubscriberSubscriptionEmail(Subscription subscription) throws Exception {
+        return createSubscriberSubscriptionEmail(Arrays.asList(new Subscription[]{subscription}));
+    }
+
+    public static MailParser createSubscriberSubscriptionEmail(List<Subscription> subscriptions) throws Exception {
+        return createSubscriptionEmail(MultiSubscription.Subscriber, subscriptions);
     }
 
     public static MailParser createSubscriberPasswordRecoveryEmail(String passwordUrl) throws Exception {
@@ -158,18 +198,17 @@ public class MailParser {
         return mailParser;
     }
 
-    private static BigDecimal convert(Double input) {
+    public static String formatPrice(Double input) {
         BigDecimal output = BigDecimal.ZERO;
-        if (input != null) output = BigDecimal.valueOf(input);
-        return output.setScale(2, BigDecimal.ROUND_HALF_EVEN);
-    }
-
-    private static String formatPrice(BigDecimal price) {
+        if (input != null) {
+            output = BigDecimal.valueOf(input);
+        }
+        output = output.setScale(2, BigDecimal.ROUND_HALF_EVEN);
         DecimalFormat decimalFormat = new DecimalFormat();
         decimalFormat.setMaximumFractionDigits(2);
         decimalFormat.setMinimumFractionDigits(2);
         decimalFormat.setGroupingUsed(false);
-        return decimalFormat.format(price);
+        return decimalFormat.format(output);
     }
 
     /*
@@ -178,12 +217,6 @@ public class MailParser {
      */
     private final StringBuilder htmlBuilder;
     private final StringBuilder textBuilder;
-
-//    public MailParser(StringBuilder htmlBuilder) {
-//        Preconditions.checkNotNull(htmlBuilder);
-//        Preconditions.checkArgument(htmlBuilder.length() > 0);
-//        this.htmlBuilder = htmlBuilder;
-//    }
 
     private MailParser(String resource) throws IOException {
         htmlBuilder = createStringBuilder(resource + ".html");
@@ -202,17 +235,29 @@ public class MailParser {
         return builder;
     }
 
-    private void substitute(SubstituteKey substituteKey, String value) {
+    private void substitute(StringBuilder stringBuilder, SubstituteKey substituteKey, String value) {
         Preconditions.checkNotNull(value);
         int indexOfTarget;
 
-        while ((indexOfTarget = htmlBuilder.indexOf(substituteKey.key)) > 0) {
-            htmlBuilder.replace(indexOfTarget, indexOfTarget + substituteKey.key.length(), value);
+        while ((indexOfTarget = stringBuilder.indexOf(substituteKey.key)) > 0) {
+            stringBuilder.replace(indexOfTarget, indexOfTarget + substituteKey.key.length(), value);
         }
+    }
 
-        while ((indexOfTarget = textBuilder.indexOf(substituteKey.key)) > 0) {
-            textBuilder.replace(indexOfTarget, indexOfTarget + substituteKey.key.length(), value);
+    private void substitute(SubstituteKey substituteKey, String value) {
+        substitute(htmlBuilder, substituteKey, value);
+        substitute(textBuilder, substituteKey, value);
+    }
+
+    private void substitute(SubstituteKey substituteKey, Collection<MailParser> mailParsers) {
+        StringBuilder tempHtmlBuilder = new StringBuilder();
+        StringBuilder tempTextBuilder = new StringBuilder();
+        for (MailParser mailParser : mailParsers) {
+            tempHtmlBuilder.append(mailParser.htmlBuilder);
+            tempTextBuilder.append(mailParser.textBuilder);
         }
+        substitute(htmlBuilder, substituteKey, tempHtmlBuilder.toString());
+        substitute(textBuilder, substituteKey, tempTextBuilder.toString());
     }
 
     public String getHtml() {

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
@@ -82,7 +82,7 @@ public class MailParser {
 
     public static MailParser createJasifyUserSignUpEmail(User user) throws Exception {
         MailParser mailParser = new MailParser("/jasify/UserSignUp");
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
         mailParser.substitute(SubstituteKey.UserName, user.getName());
         return mailParser;
     }
@@ -115,7 +115,11 @@ public class MailParser {
             activityDetails.add(MailParser.createSubscriptionActivityDetails(multiSubscription, subscription));
             if (subscriberName == null) {
                 User user = subscription.getUserRef().getModel();
-                subscriberName = user.getDisplayName();
+                if (user.getRealName() != null) {
+                    subscriberName = user.getRealName();
+                } else {
+                    subscriberName = user.getName();
+                }
             }
         }
 
@@ -152,7 +156,7 @@ public class MailParser {
         DateTime finish = new DateTime(activity.getFinish());
         MailParser mailParser = new MailParser("/publisher/Subscription");
         mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
         mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
         mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
         mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
@@ -4,8 +4,6 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.Transaction;
 import com.google.appengine.repackaged.org.joda.time.DateTime;
 import com.google.appengine.repackaged.org.joda.time.DateTimeConstants;
-import com.jasify.schedule.appengine.mail.MailParser;
-import com.jasify.schedule.appengine.mail.MailServiceFactory;
 import com.jasify.schedule.appengine.meta.activity.ActivityMeta;
 import com.jasify.schedule.appengine.meta.activity.ActivityTypeMeta;
 import com.jasify.schedule.appengine.meta.activity.RepeatDetailsMeta;
@@ -22,8 +20,6 @@ import com.jasify.schedule.appengine.model.common.Organization;
 import com.jasify.schedule.appengine.model.users.User;
 import com.jasify.schedule.appengine.util.BeanUtil;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slim3.datastore.Datastore;
 import org.slim3.datastore.EntityNotFoundRuntimeException;
 
@@ -35,7 +31,6 @@ import java.util.*;
  * @since 09/01/15.
  */
 class DefaultActivityService implements ActivityService {
-    private static final Logger log = LoggerFactory.getLogger(DefaultActivityService.class);
 
     private final ActivityTypeMeta activityTypeMeta;
     private final ActivityMeta activityMeta;
@@ -418,38 +413,6 @@ class DefaultActivityService implements ActivityService {
         return subscription;
     }
 
-    private void notify(Subscription subscription) throws EntityNotFoundException {
-        Activity activity = subscription.getActivityRef().getModel();
-        ActivityType activityType = activity.getActivityTypeRef().getModel();
-        Organization organization = getOrganization(activityType.getOrganizationRef().getKey());
-        User user = subscription.getUserRef().getModel();
-
-        String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
-
-        try {
-            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscription);
-            MailServiceFactory.getMailService().send(user.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
-        } catch (Exception e) {
-            log.error("Failed to notify subscriber", e);
-        }
-
-        try {
-            MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);
-            for (User orgUser : organization.getUsers()) {
-                MailServiceFactory.getMailService().send(orgUser.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
-            }
-        } catch (Exception e) {
-            log.error("Failed to notify publisher", e);
-        }
-
-        try {
-            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscription);
-            MailServiceFactory.getMailService().sendToApplicationOwners(subject, mailParser.getHtml(), mailParser.getText());
-        } catch (Exception e) {
-            log.error("Failed to notify jasify", e);
-        }
-    }
-
     @Nonnull
     @Override
     public Subscription subscribe(Key userId, Key activityId) throws EntityNotFoundException, UniqueConstraintException, OperationException {
@@ -478,8 +441,6 @@ class DefaultActivityService implements ActivityService {
 
         Datastore.put(dbActivity);
         Datastore.put(subscription);
-
-        notify(subscription);
 
         return subscription;
     }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
@@ -427,14 +427,14 @@ class DefaultActivityService implements ActivityService {
         String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
 
         try {
-            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscription, organization);
+            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscription);
             MailServiceFactory.getMailService().send(user.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
         } catch (Exception e) {
             log.error("Failed to notify subscriber", e);
         }
 
         try {
-            MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription, organization);
+            MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);
             for (User orgUser : organization.getUsers()) {
                 MailServiceFactory.getMailService().send(orgUser.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
             }
@@ -443,7 +443,7 @@ class DefaultActivityService implements ActivityService {
         }
 
         try {
-            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscription, organization);
+            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscription);
             MailServiceFactory.getMailService().sendToApplicationOwners(subject, mailParser.getHtml(), mailParser.getText());
         } catch (Exception e) {
             log.error("Failed to notify jasify", e);

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
@@ -1,8 +1,24 @@
 package com.jasify.schedule.appengine.model.payment.workflow;
 
+import com.google.appengine.api.datastore.Key;
+import com.jasify.schedule.appengine.mail.MailParser;
+import com.jasify.schedule.appengine.mail.MailServiceFactory;
+import com.jasify.schedule.appengine.model.EntityNotFoundException;
+import com.jasify.schedule.appengine.model.activity.Activity;
+import com.jasify.schedule.appengine.model.activity.ActivityServiceFactory;
+import com.jasify.schedule.appengine.model.activity.ActivityType;
+import com.jasify.schedule.appengine.model.activity.Subscription;
 import com.jasify.schedule.appengine.model.cart.ShoppingCartServiceFactory;
+import com.jasify.schedule.appengine.model.common.Organization;
+import com.jasify.schedule.appengine.model.payment.Payment;
+import com.jasify.schedule.appengine.model.users.User;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slim3.datastore.Model;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author krico
@@ -10,6 +26,7 @@ import org.slim3.datastore.Model;
  */
 @Model
 public class ShoppingCartPaymentWorkflow extends PaymentWorkflow {
+    private static final Logger log = LoggerFactory.getLogger(ShoppingCartPaymentWorkflow.class);
 
     private String cartId;
 
@@ -42,6 +59,84 @@ public class ShoppingCartPaymentWorkflow extends PaymentWorkflow {
     public void onCompleted() throws PaymentWorkflowException {
         if (StringUtils.isNotBlank(cartId)) {
             ShoppingCartServiceFactory.getShoppingCartService().clearCart(cartId);
+        }
+
+        sendNotifications();
+    }
+
+    protected void sendNotifications() {
+        List<Subscription> subscriptions = getSubscriptions();
+        if (subscriptions.isEmpty()) {
+            // Is this possible?
+            log.error("Empty subscription list");
+        } else {
+            notifyPublisher(subscriptions);
+            notifySubscriber(subscriptions);
+            notifyJasify(subscriptions);
+        }
+    }
+
+    private List<Subscription> getSubscriptions() {
+        List<Subscription> subscriptions = new ArrayList<>();
+        // This is probably not the best way to get the subscriptions
+        Payment payment = getPaymentRef().getModel();
+        for (PaymentWorkflow paymentWorkflow : payment.getWorkflowListRef().getModelList()) {
+            if (paymentWorkflow instanceof ActivityPaymentWorkflow) {
+                Key key = ((ActivityPaymentWorkflow)paymentWorkflow).getSubscriptionId();
+                try {
+                    subscriptions.add(ActivityServiceFactory.getActivityService().getSubscription(key));
+                } catch (EntityNotFoundException e) {
+                    log.error("Failed to find subscription with key " + key.getId(), e);
+                }
+            }
+        }
+        return subscriptions;
+    }
+
+    private void notifyPublisher(List<Subscription> subscriptions) {
+        // A Publisher gets an email per subscription
+        for (Subscription subscription : subscriptions) {
+            User user = subscription.getUserRef().getModel();
+            Activity activity = subscription.getActivityRef().getModel();
+            ActivityType activityType = activity.getActivityTypeRef().getModel();
+            Organization organization = activityType.getOrganizationRef().getModel();
+
+            String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
+
+            try {
+                MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);
+                for (User orgUser : organization.getUsers()) {
+                    MailServiceFactory.getMailService().send(orgUser.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
+                }
+            } catch (Exception e) {
+                log.error("Failed to notify publisher", e);
+            }
+        }
+    }
+
+    private void notifySubscriber(List<Subscription> subscriptions) {
+        User user = subscriptions.get(0).getUserRef().getModel();
+
+        String subject = String.format("[Jasify] Subscribe [%s]", user.getDisplayName());
+
+        try {
+            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscriptions);
+            MailServiceFactory.getMailService().send(user.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
+        } catch (Exception e) {
+            log.error("Failed to notify application owners", e);
+        }
+    }
+
+    private void notifyJasify(List<Subscription> subscriptions) {
+        User user = subscriptions.get(0).getUserRef().getModel();
+
+        String subject = String.format("[Jasify] Subscribe [%s]", user.getDisplayName());
+
+        try {
+            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscriptions);
+                MailServiceFactory.getMailService().sendToApplicationOwners(subject, mailParser.getHtml(), mailParser.getText());
+        } catch (Exception e) {
+            log.error("Failed to notify application owners", e);
         }
     }
 }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
@@ -101,7 +101,7 @@ public class ShoppingCartPaymentWorkflow extends PaymentWorkflow {
             ActivityType activityType = activity.getActivityTypeRef().getModel();
             Organization organization = activityType.getOrganizationRef().getModel();
 
-            String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
+            String subject = String.format("[Jasify] Subscribe [%s]", user.getDisplayName());
 
             try {
                 MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);

--- a/schedule/schedule-appengine/src/main/resources/jasify/Subscription.html
+++ b/schedule/schedule-appengine/src/main/resources/jasify/Subscription.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Order of %ActivityName%</title>
+    <title>Subscription Information</title>
 </head>
 <body bgcolor="#FFFFFF" link="#0066CC">
 
@@ -27,7 +27,7 @@
 
                     <td bgcolor="#FFFFFF"><font face="verdana,arial,helvetica" size="-1">
                         <p><b>Dear JASIFY team,</b></p>
-                        <p>A new subscription has been created!</p>
+                        <p>A new subscription has been created for %SubscriberName%!</p>
                     </font>
                         <table cellpadding="4" cellspacing="0" border="0" width="100%">
                             <tr>
@@ -39,67 +39,7 @@
                             <tr>
                                 <td height="148">
                                     <table border="0" cellpadding="1" cellspacing="0" width="100%" align="left">
-                                        <tr>
-                                            <td>
-                                                <p>Order # &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %OrderNumber%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Publisher &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %PublisherName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Subscriber &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %SubscriberName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <br>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Activity &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Start &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityStart%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Finish &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityFinish%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Price &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityPrice%</p>
-                                            </td>
-                                        </tr>
+                                        %ActivityDetails%
                                         <tr>
                                             <td>
                                                 <p>Fees &nbsp;</p>

--- a/schedule/schedule-appengine/src/main/resources/jasify/Subscription.txt
+++ b/schedule/schedule-appengine/src/main/resources/jasify/Subscription.txt
@@ -1,17 +1,9 @@
 Dear JASIFY team,
 
-A new subscription has been created!
+A new subscription has been created for %SubscriberName%
 
 Order Details
-Order        #: %OrderNumber%
-Publisher     : %PublisherName%
-Subscriber    : %SubscriberName%
-
-Activity      : %ActivityName%
-Start         : %ActivityStart%
-Finish        : %ActivityFinish%
-Price         : %ActivityPrice%
-
+%ActivityDetails%
 Fees          : %Fees%
 Tax           : %Tax%
 

--- a/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.html
+++ b/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.html
@@ -1,0 +1,53 @@
+<tr>
+    <td>
+        <p>Order # &nbsp;</p>
+    </td>
+    <td>
+        <p>: %OrderNumber%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Publisher &nbsp;</p>
+    </td>
+    <td>
+        <p>: %PublisherName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Activity &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Start &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityStart%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Finish &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityFinish%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Price &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityPrice%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <br>
+    </td>
+</tr>

--- a/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.txt
+++ b/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.txt
@@ -1,0 +1,7 @@
+Order        #: %OrderNumber%
+Publisher     : %PublisherName%
+Activity      : %ActivityName%
+Start         : %ActivityStart%
+Finish        : %ActivityFinish%
+Price         : %ActivityPrice%
+

--- a/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.html
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Order of %ActivityName%</title>
+    <title>Subscription Information</title>
 </head>
 <body bgcolor="#FFFFFF" link="#0066CC">
 
@@ -28,57 +28,16 @@
                             <tr>
                                 <td height="148">
                                     <table border="0" cellpadding="1" cellspacing="0" width="100%" align="left">
+                                        %ActivityDetails%
                                         <tr>
-                                            <td>
-                                                <p>Order # &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %OrderNumber%</p>
-                                            </td>
+                                            <td>&nbsp;</td>
                                         </tr>
                                         <tr>
                                             <td>
-                                                <p>Purchased From &nbsp;</p>
+                                                <p><b>Total &nbsp;</b></p>
                                             </td>
                                             <td>
-                                                <p>: %PublisherName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <br>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Activity &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Start &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityStart%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Finish &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityFinish%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Price &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityPrice%</p>
+                                                <p><b>: %TotalPrice%</b></p>
                                             </td>
                                         </tr>
                                     </table>

--- a/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.txt
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.txt
@@ -3,12 +3,8 @@ Dear %SubscriberName%,
 Thank you for your order!
 
 Order Details
-Order        #: %OrderNumber%
-Purchased From: %PublisherName%
+%ActivityDetails%
+Total         : %TotalPrice%
 
-Activity      : %ActivityName%
-Start         : %ActivityStart%
-Finish        : %ActivityFinish%
-Price         : %ActivityPrice%
 
 Thank you again for booking with Jasify

--- a/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.html
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.html
@@ -1,0 +1,53 @@
+<tr>
+    <td>
+        <p>Order # &nbsp;</p>
+    </td>
+    <td>
+        <p>: %OrderNumber%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Purchased From &nbsp;</p>
+    </td>
+    <td>
+        <p>: %PublisherName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Activity &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Start &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityStart%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Finish &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityFinish%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Price &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityPrice%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <br>
+    </td>
+</tr>

--- a/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.txt
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.txt
@@ -1,0 +1,7 @@
+Order        #: %OrderNumber%
+Purchased From: %PublisherName%
+Activity      : %ActivityName%
+Start         : %ActivityStart%
+Finish        : %ActivityFinish%
+Price         : %ActivityPrice%
+

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/mail/MailParserTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/mail/MailParserTest.java
@@ -194,6 +194,7 @@ public class MailParserTest {
         assert(text.contains(": " + activity2.getPrice()));
 
         assert(text.contains(": " + MailParser.formatPrice(activity1.getPrice() + activity2.getPrice())));
+
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/mail/MailParserTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/mail/MailParserTest.java
@@ -194,7 +194,6 @@ public class MailParserTest {
         assert(text.contains(": " + activity2.getPrice()));
 
         assert(text.contains(": " + MailParser.formatPrice(activity1.getPrice() + activity2.getPrice())));
-
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityServiceTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityServiceTest.java
@@ -11,7 +11,6 @@ import com.jasify.schedule.appengine.meta.activity.ActivityTypeMeta;
 import com.jasify.schedule.appengine.model.*;
 import com.jasify.schedule.appengine.model.activity.RepeatDetails.*;
 import com.jasify.schedule.appengine.model.common.Organization;
-import com.jasify.schedule.appengine.model.common.OrganizationServiceFactory;
 import com.jasify.schedule.appengine.model.users.User;
 import org.junit.After;
 import org.junit.Before;
@@ -807,31 +806,6 @@ public class ActivityServiceTest {
         List<Subscription> modelList = activity1Organization1.getSubscriptionListRef().getModelList();
         assertEquals(1, modelList.size());
         assertEquals(subscription.getId(), modelList.get(0).getId());
-    }
-
-    @Test
-    public void testSubscribeNotifies() throws Exception {
-        activity1Organization1.setPrice(12.2);
-        OrganizationServiceFactory.getOrganizationService().addUserToOrganization(organization1, testUser2);
-        activityService.addActivity(activity1Organization1, new RepeatDetails());
-        LocalMailService service = LocalMailServiceTestConfig.getLocalMailService();
-        service.clearSentMessages();
-        activityService.subscribe(testUser1, activity1Organization1);
-        List<MailServicePb.MailMessage> sentMessages = service.getSentMessages();
-        assertNotNull(sentMessages);
-        assertEquals(3, sentMessages.size());
-    }
-
-    @Test
-    public void testSubscribeNotifiesIfPriceIsNull() throws Exception {
-        OrganizationServiceFactory.getOrganizationService().addUserToOrganization(organization1, testUser2);
-        activityService.addActivity(activity1Organization1, new RepeatDetails());
-        LocalMailService service = LocalMailServiceTestConfig.getLocalMailService();
-        service.clearSentMessages();
-        activityService.subscribe(testUser1, activity1Organization1);
-        List<MailServicePb.MailMessage> sentMessages = service.getSentMessages();
-        assertNotNull(sentMessages);
-        assertEquals(3, sentMessages.size());
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
@@ -102,8 +102,12 @@ public class ShoppingCartPaymentWorkflowTest {
         TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
         try {
             testShoppingCartServiceFactory.setUp();
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
+
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
+                    .andReturn(new ShoppingCart(SOME_CART));
+
             testShoppingCartServiceFactory.replay();
+
             PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Completed);
         } finally {
             testShoppingCartServiceFactory.tearDown();
@@ -112,7 +116,6 @@ public class ShoppingCartPaymentWorkflowTest {
 
     @Test
     public void testOnCompletedSendsEmails() throws Exception {
-        // This test looks too big :(
         ActivityPaymentWorkflow activityPaymentWorkflow1 = createActivityPaymentWorkflow();
         Subscription subscription1 = createSubscription();
         activityPaymentWorkflow1.setSubscriptionId(subscription1.getId());
@@ -140,7 +143,9 @@ public class ShoppingCartPaymentWorkflowTest {
 
             EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription1.getId())).andReturn(subscription1);
             EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription2.getId())).andReturn(subscription2);
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
+
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
+                    .andReturn(new ShoppingCart(SOME_CART));
 
             testShoppingCartServiceFactory.replay();
             testActivityServiceFactory.replay();

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
@@ -102,12 +102,8 @@ public class ShoppingCartPaymentWorkflowTest {
         TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
         try {
             testShoppingCartServiceFactory.setUp();
-
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
-                    .andReturn(new ShoppingCart(SOME_CART));
-
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
             testShoppingCartServiceFactory.replay();
-
             PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Completed);
         } finally {
             testShoppingCartServiceFactory.tearDown();
@@ -116,6 +112,7 @@ public class ShoppingCartPaymentWorkflowTest {
 
     @Test
     public void testOnCompletedSendsEmails() throws Exception {
+        // This test looks too big :(
         ActivityPaymentWorkflow activityPaymentWorkflow1 = createActivityPaymentWorkflow();
         Subscription subscription1 = createSubscription();
         activityPaymentWorkflow1.setSubscriptionId(subscription1.getId());
@@ -143,9 +140,7 @@ public class ShoppingCartPaymentWorkflowTest {
 
             EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription1.getId())).andReturn(subscription1);
             EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription2.getId())).andReturn(subscription2);
-
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
-                    .andReturn(new ShoppingCart(SOME_CART));
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
 
             testShoppingCartServiceFactory.replay();
             testActivityServiceFactory.replay();

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
@@ -1,19 +1,69 @@
 package com.jasify.schedule.appengine.model.payment.workflow;
 
-import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.mail.MailServicePb;
+import com.google.appengine.api.mail.dev.LocalMailService;
+import com.google.appengine.tools.development.testing.LocalMailServiceTestConfig;
 import com.jasify.schedule.appengine.TestHelper;
+import com.jasify.schedule.appengine.model.activity.*;
 import com.jasify.schedule.appengine.model.cart.ShoppingCart;
 import com.jasify.schedule.appengine.model.cart.TestShoppingCartServiceFactory;
-import com.jasify.schedule.appengine.model.payment.PaymentStateEnum;
+import com.jasify.schedule.appengine.model.common.Organization;
+import com.jasify.schedule.appengine.model.common.OrganizationMember;
+import com.jasify.schedule.appengine.model.payment.*;
+import com.jasify.schedule.appengine.model.users.User;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slim3.datastore.Datastore;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
 public class ShoppingCartPaymentWorkflowTest {
     public static final String SOME_CART = "someCart";
-    private Key workflowId;
+
+    private PayPalPayment newPayment(List<PaymentWorkflow> workflows) throws PaymentException {
+        PayPalPayment payment = new PayPalPayment();
+        payment.setCurrency("USD");
+        payment.setAmount(30.35);
+        PaymentService paymentService = PaymentServiceFactory.getPaymentService();
+        paymentService.newPayment(Datastore.allocateId(User.class), payment, workflows);
+        return payment;
+    }
+
+    private User createUser() {
+        User user = new User();
+        user.setRealName("Real Name");
+        user.setName("Name");
+        user.setEmail("Em@il.com");
+        Datastore.put(user);
+        return user;
+    }
+
+    private Subscription createSubscription() throws Exception {
+        Organization organization = new Organization("Org");
+        organization.setId(Datastore.allocateId(Organization.class));
+        Datastore.put(new OrganizationMember(organization, createUser()));
+        ActivityType activityType = new ActivityType("AT");
+        activityType.getOrganizationRef().setModel(organization);
+        Activity activity = new Activity(activityType);
+        Subscription subscription = new Subscription();
+        subscription.setId(Datastore.allocateId(Subscription.class));
+        subscription.getActivityRef().setModel(activity);
+        subscription.getUserRef().setModel(createUser());
+        return subscription;
+    }
+
+    private ActivityPaymentWorkflow createActivityPaymentWorkflow() {
+        ActivityPaymentWorkflow activityPaymentWorkflow = new ActivityPaymentWorkflow();
+        Datastore.put(activityPaymentWorkflow);
+        return activityPaymentWorkflow;
+    }
 
     @Before
     public void setup() {
@@ -30,7 +80,6 @@ public class ShoppingCartPaymentWorkflowTest {
         //no op
         ShoppingCartPaymentWorkflow workflow = new ShoppingCartPaymentWorkflow(SOME_CART);
         Datastore.put(workflow);
-        workflowId = workflow.getId();
         PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Created);
     }
 
@@ -44,19 +93,69 @@ public class ShoppingCartPaymentWorkflowTest {
 
     @Test
     public void testOnCompleted() throws Exception {
-        testOnCreated();
+        ShoppingCartPaymentWorkflow workflow = new ShoppingCartPaymentWorkflow(SOME_CART);
+        Datastore.put(workflow);
+
+        newPayment(Arrays.asList(new PaymentWorkflow[]{workflow}));
+
+        PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Created);
         TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
         try {
             testShoppingCartServiceFactory.setUp();
-
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
-                    .andReturn(new ShoppingCart(SOME_CART));
-
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
             testShoppingCartServiceFactory.replay();
-
-            PaymentWorkflowEngine.transition(workflowId, PaymentStateEnum.Completed);
+            PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Completed);
         } finally {
             testShoppingCartServiceFactory.tearDown();
+        }
+    }
+
+    @Test
+    public void testOnCompletedSendsEmails() throws Exception {
+        // This test looks too big :(
+        ActivityPaymentWorkflow activityPaymentWorkflow1 = createActivityPaymentWorkflow();
+        Subscription subscription1 = createSubscription();
+        activityPaymentWorkflow1.setSubscriptionId(subscription1.getId());
+
+        ActivityPaymentWorkflow activityPaymentWorkflow2 = createActivityPaymentWorkflow();
+        Subscription subscription2 = createSubscription();
+        activityPaymentWorkflow2.setSubscriptionId(subscription2.getId());
+
+        ShoppingCartPaymentWorkflow shoppingCartPaymentWorkflow = new ShoppingCartPaymentWorkflow(SOME_CART);
+        Datastore.put(shoppingCartPaymentWorkflow);
+
+        List<PaymentWorkflow> workflows = new ArrayList<>();
+        workflows.add(activityPaymentWorkflow1);
+        workflows.add(activityPaymentWorkflow2);
+        workflows.add(shoppingCartPaymentWorkflow);
+        newPayment(workflows);
+
+        PaymentWorkflowEngine.transition(shoppingCartPaymentWorkflow.getId(), PaymentStateEnum.Created);
+        TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
+        TestActivityServiceFactory testActivityServiceFactory = new TestActivityServiceFactory();
+
+        try {
+            testShoppingCartServiceFactory.setUp();
+            testActivityServiceFactory.setUp();
+
+            EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription1.getId())).andReturn(subscription1);
+            EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription2.getId())).andReturn(subscription2);
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
+
+            testShoppingCartServiceFactory.replay();
+            testActivityServiceFactory.replay();
+
+            LocalMailService localMailService = LocalMailServiceTestConfig.getLocalMailService();
+            localMailService.clearSentMessages();
+
+            PaymentWorkflowEngine.transition(shoppingCartPaymentWorkflow.getId(), PaymentStateEnum.Completed);
+            List<MailServicePb.MailMessage> sentMessages = localMailService.getSentMessages();
+            assertNotNull(sentMessages);
+            // One for Jasify, One for Subscriber, Two for Publisher
+            assertEquals(4, sentMessages.size());
+        } finally {
+            testShoppingCartServiceFactory.tearDown();
+            testActivityServiceFactory.tearDown();
         }
     }
 }


### PR DESCRIPTION
Fixes #251
Fixes #224 

* Simplified MailParser to only require the subscription object
* Jasify and Subscriber subscription emails now support multiple subscriptions in one email. This is done via embedded MailParser's per activity subscriptions
* Publisher continues to get individual emails.
* Moved subscription notification from DefaultActivityService.subscribe to ShoppingCartPaymentWorkflow.onCompleted