### PR TITLE
Extend activity type

### DIFF
--- a/schedule/schedule-appengine/src/main/client/jasify/admin/activity/admin-activity.html
+++ b/schedule/schedule-appengine/src/main/client/jasify/admin/activity/admin-activity.html
@@ -32,7 +32,7 @@
                     <div class="col-sm-8 has-feedback" ng-class="vm.hasActivityTypes() ? false : 'has-error'">
                         <select ng-model="vm.activity.activityType" id="activityType" class="form-control"
                                 ng-options="activityType as activityType.name for activityType in vm.activityTypes"
-                                ng-change="vm.activity.description = vm.activity.activityType.description">
+                                ng-change="vm.activityTypeChanged()">
                         </select>
 
                         <div class="help-block small" ng-hide="vm.hasActivityTypes()">

--- a/schedule/schedule-appengine/src/main/client/jasify/admin/activity/admin-activity.js
+++ b/schedule/schedule-appengine/src/main/client/jasify/admin/activity/admin-activity.js
@@ -30,6 +30,7 @@
         vm.selectActivityType = selectActivityType;
         vm.loadActivityTypes = loadActivityTypes;
         vm.hasActivityTypes = hasActivityTypes;
+        vm.activityTypeChanged = activityTypeChanged;
         vm.alert = alert;
         vm.update = update;
         vm.create = create;
@@ -112,10 +113,6 @@
             function ok(r) {
                 vm.loadingActivityTypes = false;
                 vm.activityTypes = r.items;
-                if (vm.activityTypes.length == 1) {
-                    vm.activity.activityType = vm.activityTypes[0];
-                    vm.activity.description = vm.activityTypes[0].description;
-                }
                 vm.selectActivityType(vm.activityTypes, vm.activity);
             }
 
@@ -145,14 +142,24 @@
         }
 
         function selectActivityType(activityTypes, activity) {
-
             if (activity.activityType && activity.activityType.id) {
                 angular.forEach(activityTypes, function (value, key) {
                     if (activity.activityType.id == value.id) {
                         vm.activity.activityType = value;
                     }
                 });
+            } else if (vm.activityTypes.length == 1) {
+                vm.activity.activityType = vm.activityTypes[0];
+                vm.activityTypeChanged();
             }
+        }
+
+        function activityTypeChanged() {
+            vm.activity.description = vm.activity.activityType.description;
+            vm.activity.price = vm.activity.activityType.price;
+            vm.activity.currency = vm.activity.activityType.currency;
+            vm.activity.location = vm.activity.activityType.location;
+            vm.activity.maxSubscriptions = vm.activity.activityType.maxSubscriptions;
         }
 
         function create() {

--- a/schedule/schedule-appengine/src/main/client/jasify/admin/organization/admin-organization-activity-type.html
+++ b/schedule/schedule-appengine/src/main/client/jasify/admin/organization/admin-organization-activity-type.html
@@ -4,23 +4,60 @@
 <div class="modal-body">
     <form class="form-horizontal" role="form" name="vm.activityTypeForm" novalidate>
         <div class="form-group">
-            <label class="col-sm-2 control-label input-sm">name:</label>
+            <label class="col-sm-3 control-label input-sm">name:</label>
 
-            <div class="col-sm-10">
+            <div class="col-sm-9">
                 <input type="text" class="form-control input-sm" id="name" name="name"
                        ng-model="vm.activityType.name"
                        placeholder="name">
             </div>
         </div>
         <div class="form-group">
-            <label fo="description" class="col-sm-2 control-label input-sm">description:</label>
+            <label fo="description" class="col-sm-3 control-label input-sm">description:</label>
 
-            <div class="col-sm-10">
-                    <textarea class="form-control input-sm"
+            <div class="col-sm-9">
+                <textarea class="form-control input-sm"
                               id="description"
                               ng-model="vm.activityType.description"
                               placeholder="description"
                               rows="3" maxlength="255"></textarea>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="price" class="col-sm-3 control-label input-sm">price:</label>
+
+            <div class="col-sm-7">
+                <input class="form-control input-sm"
+                       id="price"
+                       ng-model="vm.activityType.price"
+                       placeholder="price"
+                       type="number"
+                       min="0"/>
+            </div>
+            <div class="col-sm-2 text-left">
+                <select ng-model="vm.activityType.currency" class="form-control input-sm" placeholder="currency">
+                    <option>CHF</option>
+                </select>
+            </div>
+        </div>
+        <div class="form-group">
+            <label fo="location" class="col-sm-3 control-label input-sm">location:</label>
+
+            <div class="col-sm-9">
+                <input class="form-control input-sm"
+                       id="location"
+                       ng-model="vm.activityType.location"
+                       placeholder="location"/>
+            </div>
+        </div>
+        <div class="form-group">
+            <label fo="maxSubscriptions" class="col-sm-3 control-label input-sm">subscriptions(max):</label>
+
+            <div class="col-sm-9">
+                <input class="form-control input-sm"
+                       id="maxSubscriptions" type="number" min="0"
+                       ng-model="vm.activityType.maxSubscriptions"
+                       placeholder="subscriptions(max)"/>
             </div>
         </div>
     </form>

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
@@ -5,6 +5,7 @@ import com.google.appengine.repackaged.org.joda.time.format.DateTimeFormat;
 import com.google.appengine.repackaged.org.joda.time.format.DateTimeFormatter;
 import com.google.common.base.Preconditions;
 import com.jasify.schedule.appengine.model.activity.Activity;
+import com.jasify.schedule.appengine.model.activity.ActivityType;
 import com.jasify.schedule.appengine.model.activity.Subscription;
 import com.jasify.schedule.appengine.model.common.Organization;
 import com.jasify.schedule.appengine.model.users.User;
@@ -14,17 +15,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
 import java.text.DecimalFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * @author wszarmach
  * @since 14/02/15.
- * Temporary class to create html emails
+ * Temporary class to create html/text emails
  */
 public class MailParser {
 
     private static final DateTimeFormatter dtf = DateTimeFormat.forPattern("dd/MM/yyyy HH:mm");
 
     private enum SubstituteKey {
+        ActivityDetails("%ActivityDetails%"),
         ActivityFinish("%ActivityFinish%"),
         ActivityName("%ActivityName%"),
         ActivityPrice("%ActivityPrice%"),
@@ -51,6 +57,19 @@ public class MailParser {
         }
     }
 
+    private enum MultiSubscription {
+        Jasify("/jasify/Subscription", "/jasify/SubscriptionActivityDetails"),
+        Subscriber("/subscriber/Subscription", "/subscriber/SubscriptionActivityDetails");
+
+        String subscription;
+        String activityDetails;
+
+        MultiSubscription(String subscription, String activityDetails) {
+            this.subscription = subscription;
+            this.activityDetails = activityDetails;
+        }
+    }
+
     public static MailParser createNewVersionEmail(String version, String timestamp, String branch, String number, String jasifyUrl) throws Exception {
         MailParser mailParser = new MailParser("/jasify/NewVersion");
         mailParser.substitute(SubstituteKey.Version, version);
@@ -63,70 +82,91 @@ public class MailParser {
 
     public static MailParser createJasifyUserSignUpEmail(User user) throws Exception {
         MailParser mailParser = new MailParser("/jasify/UserSignUp");
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
         mailParser.substitute(SubstituteKey.UserName, user.getName());
         return mailParser;
     }
 
-    public static MailParser createJasifySubscriptionEmail(Subscription subscription, Organization organization) throws Exception {
-        String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
-        User user = subscription.getUserRef().getModel();
+    private static MailParser createSubscriptionActivityDetails(MultiSubscription multiSubscription, Subscription subscription) throws IOException {
         Activity activity = subscription.getActivityRef().getModel();
-        BigDecimal bdActivityPrice = convert(activity.getPrice());
-        BigDecimal bdFees = convert(0.0);
-        BigDecimal bdTax = convert(0.0);
+        ActivityType activityType = activity.getActivityTypeRef().getModel();
+        Organization organization = activityType.getOrganizationRef().getModel();
+        String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
         DateTime start = new DateTime(activity.getStart());
         DateTime finish = new DateTime(activity.getFinish());
-        MailParser mailParser = new MailParser("/jasify/Subscription");
+        MailParser mailParser = new MailParser(multiSubscription.activityDetails);
         mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
         mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
         mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
         mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));
         mailParser.substitute(SubstituteKey.ActivityFinish, finish.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(bdActivityPrice));
-        mailParser.substitute(SubstituteKey.Fees, formatPrice(bdFees));
-        mailParser.substitute(SubstituteKey.Tax, formatPrice(bdTax));
-        BigDecimal bdTotalPrice = convert(bdActivityPrice.add(bdFees).add(bdTax).doubleValue());
-        mailParser.substitute(SubstituteKey.TotalPrice, formatPrice(bdTotalPrice));
+        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(activity.getPrice()));
+        return mailParser;
+    }
+
+    private static MailParser createSubscriptionEmail(MultiSubscription multiSubscription, List<Subscription> subscriptions) throws Exception {
+        double totalPrice = 0;
+        String subscriberName = null;
+        List<MailParser> activityDetails = new ArrayList<>();
+        for (Subscription subscription : subscriptions) {
+            if (subscription.getActivityRef().getModel().getPrice() != null) {
+                totalPrice += subscription.getActivityRef().getModel().getPrice();
+            }
+            activityDetails.add(MailParser.createSubscriptionActivityDetails(multiSubscription, subscription));
+            if (subscriberName == null) {
+                User user = subscription.getUserRef().getModel();
+                subscriberName = user.getDisplayName();
+            }
+        }
+
+        double fees = 0.0;
+        double tax = 0.0;
+        totalPrice = totalPrice + fees + tax;
+
+        MailParser mailParser = new MailParser(multiSubscription.subscription);
+        mailParser.substitute(SubstituteKey.SubscriberName, subscriberName);
+        mailParser.substitute(SubstituteKey.ActivityDetails, activityDetails);
+        mailParser.substitute(SubstituteKey.Fees, formatPrice(fees));
+        mailParser.substitute(SubstituteKey.Tax, formatPrice(tax));
+        mailParser.substitute(SubstituteKey.TotalPrice, formatPrice(totalPrice));
         mailParser.substitute(SubstituteKey.PaymentMethod, "Unknown");
         return mailParser;
     }
 
-    public static MailParser createPublisherSubscriptionEmail(Subscription subscription, Organization organization) throws Exception {
+    public static MailParser createJasifySubscriptionEmail(Subscription subscription) throws Exception {
+        return createJasifySubscriptionEmail(Arrays.asList(new Subscription[]{subscription}));
+    }
+
+    public static MailParser createJasifySubscriptionEmail(List<Subscription> subscriptions) throws Exception {
+        return createSubscriptionEmail(MultiSubscription.Jasify, subscriptions);
+    }
+
+    public static MailParser createPublisherSubscriptionEmail(Subscription subscription) throws Exception {
+        Activity activity = subscription.getActivityRef().getModel();
+        ActivityType activityType = activity.getActivityTypeRef().getModel();
+        Organization organization = activityType.getOrganizationRef().getModel();
+
         String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
         User user = subscription.getUserRef().getModel();
-        Activity activity = subscription.getActivityRef().getModel();
-        BigDecimal bdActivityPrice = convert(activity.getPrice());
         DateTime start = new DateTime(activity.getStart());
         DateTime finish = new DateTime(activity.getFinish());
         MailParser mailParser = new MailParser("/publisher/Subscription");
         mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
         mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
         mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
         mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));
         mailParser.substitute(SubstituteKey.ActivityFinish, finish.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(bdActivityPrice));
+        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(activity.getPrice()));
         return mailParser;
     }
 
-    public static MailParser createSubscriberSubscriptionEmail(Subscription subscription, Organization organization) throws Exception {
-        String orderNumber = KeyUtil.toHumanReadableString(subscription.getId());
-        User user = subscription.getUserRef().getModel();
-        Activity activity = subscription.getActivityRef().getModel();
-        BigDecimal bdActivityPrice = convert(activity.getPrice());
-        DateTime start = new DateTime(activity.getStart());
-        DateTime finish = new DateTime(activity.getFinish());
-        MailParser mailParser = new MailParser("/subscriber/Subscription");
-        mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
-        mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
-        mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
-        mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityFinish, finish.toString(dtf));
-        mailParser.substitute(SubstituteKey.ActivityPrice, formatPrice(bdActivityPrice));
-        return mailParser;
+    public static MailParser createSubscriberSubscriptionEmail(Subscription subscription) throws Exception {
+        return createSubscriberSubscriptionEmail(Arrays.asList(new Subscription[]{subscription}));
+    }
+
+    public static MailParser createSubscriberSubscriptionEmail(List<Subscription> subscriptions) throws Exception {
+        return createSubscriptionEmail(MultiSubscription.Subscriber, subscriptions);
     }
 
     public static MailParser createSubscriberPasswordRecoveryEmail(String passwordUrl) throws Exception {
@@ -158,18 +198,17 @@ public class MailParser {
         return mailParser;
     }
 
-    private static BigDecimal convert(Double input) {
+    public static String formatPrice(Double input) {
         BigDecimal output = BigDecimal.ZERO;
-        if (input != null) output = BigDecimal.valueOf(input);
-        return output.setScale(2, BigDecimal.ROUND_HALF_EVEN);
-    }
-
-    private static String formatPrice(BigDecimal price) {
+        if (input != null) {
+            output = BigDecimal.valueOf(input);
+        }
+        output = output.setScale(2, BigDecimal.ROUND_HALF_EVEN);
         DecimalFormat decimalFormat = new DecimalFormat();
         decimalFormat.setMaximumFractionDigits(2);
         decimalFormat.setMinimumFractionDigits(2);
         decimalFormat.setGroupingUsed(false);
-        return decimalFormat.format(price);
+        return decimalFormat.format(output);
     }
 
     /*
@@ -178,12 +217,6 @@ public class MailParser {
      */
     private final StringBuilder htmlBuilder;
     private final StringBuilder textBuilder;
-
-//    public MailParser(StringBuilder htmlBuilder) {
-//        Preconditions.checkNotNull(htmlBuilder);
-//        Preconditions.checkArgument(htmlBuilder.length() > 0);
-//        this.htmlBuilder = htmlBuilder;
-//    }
 
     private MailParser(String resource) throws IOException {
         htmlBuilder = createStringBuilder(resource + ".html");
@@ -202,17 +235,29 @@ public class MailParser {
         return builder;
     }
 
-    private void substitute(SubstituteKey substituteKey, String value) {
+    private void substitute(StringBuilder stringBuilder, SubstituteKey substituteKey, String value) {
         Preconditions.checkNotNull(value);
         int indexOfTarget;
 
-        while ((indexOfTarget = htmlBuilder.indexOf(substituteKey.key)) > 0) {
-            htmlBuilder.replace(indexOfTarget, indexOfTarget + substituteKey.key.length(), value);
+        while ((indexOfTarget = stringBuilder.indexOf(substituteKey.key)) > 0) {
+            stringBuilder.replace(indexOfTarget, indexOfTarget + substituteKey.key.length(), value);
         }
+    }
 
-        while ((indexOfTarget = textBuilder.indexOf(substituteKey.key)) > 0) {
-            textBuilder.replace(indexOfTarget, indexOfTarget + substituteKey.key.length(), value);
+    private void substitute(SubstituteKey substituteKey, String value) {
+        substitute(htmlBuilder, substituteKey, value);
+        substitute(textBuilder, substituteKey, value);
+    }
+
+    private void substitute(SubstituteKey substituteKey, Collection<MailParser> mailParsers) {
+        StringBuilder tempHtmlBuilder = new StringBuilder();
+        StringBuilder tempTextBuilder = new StringBuilder();
+        for (MailParser mailParser : mailParsers) {
+            tempHtmlBuilder.append(mailParser.htmlBuilder);
+            tempTextBuilder.append(mailParser.textBuilder);
         }
+        substitute(htmlBuilder, substituteKey, tempHtmlBuilder.toString());
+        substitute(textBuilder, substituteKey, tempTextBuilder.toString());
     }
 
     public String getHtml() {

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/mail/MailParser.java
@@ -82,7 +82,7 @@ public class MailParser {
 
     public static MailParser createJasifyUserSignUpEmail(User user) throws Exception {
         MailParser mailParser = new MailParser("/jasify/UserSignUp");
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
         mailParser.substitute(SubstituteKey.UserName, user.getName());
         return mailParser;
     }
@@ -115,7 +115,11 @@ public class MailParser {
             activityDetails.add(MailParser.createSubscriptionActivityDetails(multiSubscription, subscription));
             if (subscriberName == null) {
                 User user = subscription.getUserRef().getModel();
-                subscriberName = user.getDisplayName();
+                if (user.getRealName() != null) {
+                    subscriberName = user.getRealName();
+                } else {
+                    subscriberName = user.getName();
+                }
             }
         }
 
@@ -152,7 +156,7 @@ public class MailParser {
         DateTime finish = new DateTime(activity.getFinish());
         MailParser mailParser = new MailParser("/publisher/Subscription");
         mailParser.substitute(SubstituteKey.OrderNumber, orderNumber);
-        mailParser.substitute(SubstituteKey.SubscriberName, user.getDisplayName());
+        mailParser.substitute(SubstituteKey.SubscriberName, user.getRealName());
         mailParser.substitute(SubstituteKey.PublisherName, organization.getName());
         mailParser.substitute(SubstituteKey.ActivityName, activity.getName());
         mailParser.substitute(SubstituteKey.ActivityStart, start.toString(dtf));

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/meta/activity/ActivityTypeMeta.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/meta/activity/ActivityTypeMeta.java
@@ -23,6 +23,18 @@ public final class ActivityTypeMeta extends org.slim3.datastore.ModelMeta<com.ja
     public final org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType> description = new org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType>(this, "description", "description");
 
     /** */
+    public final org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType, java.lang.Double> price = new org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType, java.lang.Double>(this, "price", "price", java.lang.Double.class);
+
+    /** */
+    public final org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType> currency = new org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType>(this, "currency", "currency");
+
+    /** */
+    public final org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType> location = new org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType>(this, "location", "location");
+
+    /** */
+    public final org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType, java.lang.Integer> maxSubscriptions = new org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType, java.lang.Integer>(this, "maxSubscriptions", "maxSubscriptions", int.class);
+
+    /** */
     public final org.slim3.datastore.ModelRefAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType, org.slim3.datastore.ModelRef<com.jasify.schedule.appengine.model.common.Organization>, com.jasify.schedule.appengine.model.common.Organization> organizationRef = new org.slim3.datastore.ModelRefAttributeMeta<com.jasify.schedule.appengine.model.activity.ActivityType, org.slim3.datastore.ModelRef<com.jasify.schedule.appengine.model.common.Organization>, com.jasify.schedule.appengine.model.common.Organization>(this, "organizationRef", "organizationRef", org.slim3.datastore.ModelRef.class, com.jasify.schedule.appengine.model.common.Organization.class);
 
     private static final org.slim3.datastore.CreationDate slim3_createdAttributeListener = new org.slim3.datastore.CreationDate();
@@ -54,6 +66,10 @@ public final class ActivityTypeMeta extends org.slim3.datastore.ModelMeta<com.ja
         model.setName((java.lang.String) entity.getProperty("name"));
         model.setLcName((java.lang.String) entity.getProperty("lcName"));
         model.setDescription((java.lang.String) entity.getProperty("description"));
+        model.setPrice((java.lang.Double) entity.getProperty("price"));
+        model.setCurrency((java.lang.String) entity.getProperty("currency"));
+        model.setLocation((java.lang.String) entity.getProperty("location"));
+        model.setMaxSubscriptions(longToPrimitiveInt((java.lang.Long) entity.getProperty("maxSubscriptions")));
         if (model.getOrganizationRef() == null) {
             throw new NullPointerException("The property(organizationRef) is null.");
         }
@@ -75,6 +91,10 @@ public final class ActivityTypeMeta extends org.slim3.datastore.ModelMeta<com.ja
         entity.setProperty("name", m.getName());
         entity.setProperty("lcName", m.getLcName());
         entity.setProperty("description", m.getDescription());
+        entity.setProperty("price", m.getPrice());
+        entity.setProperty("currency", m.getCurrency());
+        entity.setProperty("location", m.getLocation());
+        entity.setProperty("maxSubscriptions", m.getMaxSubscriptions());
         if (m.getOrganizationRef() == null) {
             throw new NullPointerException("The property(organizationRef) must not be null.");
         }
@@ -170,6 +190,20 @@ public final class ActivityTypeMeta extends org.slim3.datastore.ModelMeta<com.ja
             writer.setNextPropertyName("description");
             encoder0.encode(writer, m.getDescription());
         }
+        if(m.getPrice() != null){
+            writer.setNextPropertyName("price");
+            encoder0.encode(writer, m.getPrice());
+        }
+        if(m.getCurrency() != null){
+            writer.setNextPropertyName("currency");
+            encoder0.encode(writer, m.getCurrency());
+        }
+        if(m.getLocation() != null){
+            writer.setNextPropertyName("location");
+            encoder0.encode(writer, m.getLocation());
+        }
+        writer.setNextPropertyName("maxSubscriptions");
+        encoder0.encode(writer, m.getMaxSubscriptions());
         if(m.getOrganizationRef() != null && m.getOrganizationRef().getKey() != null){
             writer.setNextPropertyName("organizationRef");
             encoder0.encode(writer, m.getOrganizationRef(), maxDepth, currentDepth);
@@ -194,6 +228,14 @@ public final class ActivityTypeMeta extends org.slim3.datastore.ModelMeta<com.ja
         m.setLcName(decoder0.decode(reader, m.getLcName()));
         reader = rootReader.newObjectReader("description");
         m.setDescription(decoder0.decode(reader, m.getDescription()));
+        reader = rootReader.newObjectReader("price");
+        m.setPrice(decoder0.decode(reader, m.getPrice()));
+        reader = rootReader.newObjectReader("currency");
+        m.setCurrency(decoder0.decode(reader, m.getCurrency()));
+        reader = rootReader.newObjectReader("location");
+        m.setLocation(decoder0.decode(reader, m.getLocation()));
+        reader = rootReader.newObjectReader("maxSubscriptions");
+        m.setMaxSubscriptions(decoder0.decode(reader, m.getMaxSubscriptions()));
         reader = rootReader.newObjectReader("organizationRef");
         decoder0.decode(reader, m.getOrganizationRef(), maxDepth, currentDepth);
         return m;

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/ActivityType.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/ActivityType.java
@@ -30,6 +30,14 @@ public class ActivityType {
 
     private String description;
 
+    private Double price;
+
+    private String currency;
+
+    private String location;
+
+    private int maxSubscriptions;
+
     private ModelRef<Organization> organizationRef = new ModelRef<>(Organization.class);
 
     public ActivityType() {
@@ -90,5 +98,37 @@ public class ActivityType {
 
     public ModelRef<Organization> getOrganizationRef() {
         return organizationRef;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public int getMaxSubscriptions() {
+        return maxSubscriptions;
+    }
+
+    public void setMaxSubscriptions(int maxSubscriptions) {
+        this.maxSubscriptions = maxSubscriptions;
     }
 }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
@@ -4,8 +4,6 @@ import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.Transaction;
 import com.google.appengine.repackaged.org.joda.time.DateTime;
 import com.google.appengine.repackaged.org.joda.time.DateTimeConstants;
-import com.jasify.schedule.appengine.mail.MailParser;
-import com.jasify.schedule.appengine.mail.MailServiceFactory;
 import com.jasify.schedule.appengine.meta.activity.ActivityMeta;
 import com.jasify.schedule.appengine.meta.activity.ActivityTypeMeta;
 import com.jasify.schedule.appengine.meta.activity.RepeatDetailsMeta;
@@ -22,8 +20,6 @@ import com.jasify.schedule.appengine.model.common.Organization;
 import com.jasify.schedule.appengine.model.users.User;
 import com.jasify.schedule.appengine.util.BeanUtil;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.slim3.datastore.Datastore;
 import org.slim3.datastore.EntityNotFoundRuntimeException;
 
@@ -35,7 +31,6 @@ import java.util.*;
  * @since 09/01/15.
  */
 class DefaultActivityService implements ActivityService {
-    private static final Logger log = LoggerFactory.getLogger(DefaultActivityService.class);
 
     private final ActivityTypeMeta activityTypeMeta;
     private final ActivityMeta activityMeta;
@@ -418,38 +413,6 @@ class DefaultActivityService implements ActivityService {
         return subscription;
     }
 
-    private void notify(Subscription subscription) throws EntityNotFoundException {
-        Activity activity = subscription.getActivityRef().getModel();
-        ActivityType activityType = activity.getActivityTypeRef().getModel();
-        Organization organization = getOrganization(activityType.getOrganizationRef().getKey());
-        User user = subscription.getUserRef().getModel();
-
-        String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
-
-        try {
-            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscription);
-            MailServiceFactory.getMailService().send(user.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
-        } catch (Exception e) {
-            log.error("Failed to notify subscriber", e);
-        }
-
-        try {
-            MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);
-            for (User orgUser : organization.getUsers()) {
-                MailServiceFactory.getMailService().send(orgUser.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
-            }
-        } catch (Exception e) {
-            log.error("Failed to notify publisher", e);
-        }
-
-        try {
-            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscription);
-            MailServiceFactory.getMailService().sendToApplicationOwners(subject, mailParser.getHtml(), mailParser.getText());
-        } catch (Exception e) {
-            log.error("Failed to notify jasify", e);
-        }
-    }
-
     @Nonnull
     @Override
     public Subscription subscribe(Key userId, Key activityId) throws EntityNotFoundException, UniqueConstraintException, OperationException {
@@ -478,8 +441,6 @@ class DefaultActivityService implements ActivityService {
 
         Datastore.put(dbActivity);
         Datastore.put(subscription);
-
-        notify(subscription);
 
         return subscription;
     }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
@@ -192,6 +192,10 @@ class DefaultActivityService implements ActivityService {
                 }
             }
             dbActivityType.setDescription(activityType.getDescription());
+            dbActivityType.setPrice(activityType.getPrice());
+            dbActivityType.setCurrency(activityType.getCurrency());
+            dbActivityType.setLocation(activityType.getLocation());
+            dbActivityType.setMaxSubscriptions(activityType.getMaxSubscriptions());
             Datastore.put(tx, dbActivityType);
             tx.commit();
         } finally {

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/activity/DefaultActivityService.java
@@ -427,14 +427,14 @@ class DefaultActivityService implements ActivityService {
         String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
 
         try {
-            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscription, organization);
+            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscription);
             MailServiceFactory.getMailService().send(user.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
         } catch (Exception e) {
             log.error("Failed to notify subscriber", e);
         }
 
         try {
-            MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription, organization);
+            MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);
             for (User orgUser : organization.getUsers()) {
                 MailServiceFactory.getMailService().send(orgUser.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
             }
@@ -443,7 +443,7 @@ class DefaultActivityService implements ActivityService {
         }
 
         try {
-            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscription, organization);
+            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscription);
             MailServiceFactory.getMailService().sendToApplicationOwners(subject, mailParser.getHtml(), mailParser.getText());
         } catch (Exception e) {
             log.error("Failed to notify jasify", e);

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
@@ -1,8 +1,24 @@
 package com.jasify.schedule.appengine.model.payment.workflow;
 
+import com.google.appengine.api.datastore.Key;
+import com.jasify.schedule.appengine.mail.MailParser;
+import com.jasify.schedule.appengine.mail.MailServiceFactory;
+import com.jasify.schedule.appengine.model.EntityNotFoundException;
+import com.jasify.schedule.appengine.model.activity.Activity;
+import com.jasify.schedule.appengine.model.activity.ActivityServiceFactory;
+import com.jasify.schedule.appengine.model.activity.ActivityType;
+import com.jasify.schedule.appengine.model.activity.Subscription;
 import com.jasify.schedule.appengine.model.cart.ShoppingCartServiceFactory;
+import com.jasify.schedule.appengine.model.common.Organization;
+import com.jasify.schedule.appengine.model.payment.Payment;
+import com.jasify.schedule.appengine.model.users.User;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slim3.datastore.Model;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * @author krico
@@ -10,6 +26,7 @@ import org.slim3.datastore.Model;
  */
 @Model
 public class ShoppingCartPaymentWorkflow extends PaymentWorkflow {
+    private static final Logger log = LoggerFactory.getLogger(ShoppingCartPaymentWorkflow.class);
 
     private String cartId;
 
@@ -42,6 +59,84 @@ public class ShoppingCartPaymentWorkflow extends PaymentWorkflow {
     public void onCompleted() throws PaymentWorkflowException {
         if (StringUtils.isNotBlank(cartId)) {
             ShoppingCartServiceFactory.getShoppingCartService().clearCart(cartId);
+        }
+
+        sendNotifications();
+    }
+
+    protected void sendNotifications() {
+        List<Subscription> subscriptions = getSubscriptions();
+        if (subscriptions.isEmpty()) {
+            // Is this possible?
+            log.error("Empty subscription list");
+        } else {
+            notifyPublisher(subscriptions);
+            notifySubscriber(subscriptions);
+            notifyJasify(subscriptions);
+        }
+    }
+
+    private List<Subscription> getSubscriptions() {
+        List<Subscription> subscriptions = new ArrayList<>();
+        // This is probably not the best way to get the subscriptions
+        Payment payment = getPaymentRef().getModel();
+        for (PaymentWorkflow paymentWorkflow : payment.getWorkflowListRef().getModelList()) {
+            if (paymentWorkflow instanceof ActivityPaymentWorkflow) {
+                Key key = ((ActivityPaymentWorkflow)paymentWorkflow).getSubscriptionId();
+                try {
+                    subscriptions.add(ActivityServiceFactory.getActivityService().getSubscription(key));
+                } catch (EntityNotFoundException e) {
+                    log.error("Failed to find subscription with key " + key.getId(), e);
+                }
+            }
+        }
+        return subscriptions;
+    }
+
+    private void notifyPublisher(List<Subscription> subscriptions) {
+        // A Publisher gets an email per subscription
+        for (Subscription subscription : subscriptions) {
+            User user = subscription.getUserRef().getModel();
+            Activity activity = subscription.getActivityRef().getModel();
+            ActivityType activityType = activity.getActivityTypeRef().getModel();
+            Organization organization = activityType.getOrganizationRef().getModel();
+
+            String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
+
+            try {
+                MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);
+                for (User orgUser : organization.getUsers()) {
+                    MailServiceFactory.getMailService().send(orgUser.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
+                }
+            } catch (Exception e) {
+                log.error("Failed to notify publisher", e);
+            }
+        }
+    }
+
+    private void notifySubscriber(List<Subscription> subscriptions) {
+        User user = subscriptions.get(0).getUserRef().getModel();
+
+        String subject = String.format("[Jasify] Subscribe [%s]", user.getDisplayName());
+
+        try {
+            MailParser mailParser = MailParser.createSubscriberSubscriptionEmail(subscriptions);
+            MailServiceFactory.getMailService().send(user.getEmail(), subject, mailParser.getHtml(), mailParser.getText());
+        } catch (Exception e) {
+            log.error("Failed to notify application owners", e);
+        }
+    }
+
+    private void notifyJasify(List<Subscription> subscriptions) {
+        User user = subscriptions.get(0).getUserRef().getModel();
+
+        String subject = String.format("[Jasify] Subscribe [%s]", user.getDisplayName());
+
+        try {
+            MailParser mailParser = MailParser.createJasifySubscriptionEmail(subscriptions);
+                MailServiceFactory.getMailService().sendToApplicationOwners(subject, mailParser.getHtml(), mailParser.getText());
+        } catch (Exception e) {
+            log.error("Failed to notify application owners", e);
         }
     }
 }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflow.java
@@ -101,7 +101,7 @@ public class ShoppingCartPaymentWorkflow extends PaymentWorkflow {
             ActivityType activityType = activity.getActivityTypeRef().getModel();
             Organization organization = activityType.getOrganizationRef().getModel();
 
-            String subject = String.format("[Jasify] Subscribe [%s]", user.getName());
+            String subject = String.format("[Jasify] Subscribe [%s]", user.getDisplayName());
 
             try {
                 MailParser mailParser = MailParser.createPublisherSubscriptionEmail(subscription);

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/dm/JasActivityType.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/dm/JasActivityType.java
@@ -9,6 +9,10 @@ public class JasActivityType implements JasEndpointEntity {
     private String name;
     private String description;
     private String organizationId;
+    private Double price;
+    private String currency;
+    private String location;
+    private int maxSubscriptions;
 
     public String getId() {
         return id;
@@ -40,5 +44,37 @@ public class JasActivityType implements JasEndpointEntity {
 
     public void setOrganizationId(String organizationId) {
         this.organizationId = organizationId;
+    }
+
+    public Double getPrice() {
+        return price;
+    }
+
+    public void setPrice(Double price) {
+        this.price = price;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public void setCurrency(String currency) {
+        this.currency = currency;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public int getMaxSubscriptions() {
+        return maxSubscriptions;
+    }
+
+    public void setMaxSubscriptions(int maxSubscriptions) {
+        this.maxSubscriptions = maxSubscriptions;
     }
 }

--- a/schedule/schedule-appengine/src/main/resources/jasify/Subscription.html
+++ b/schedule/schedule-appengine/src/main/resources/jasify/Subscription.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Order of %ActivityName%</title>
+    <title>Subscription Information</title>
 </head>
 <body bgcolor="#FFFFFF" link="#0066CC">
 
@@ -27,7 +27,7 @@
 
                     <td bgcolor="#FFFFFF"><font face="verdana,arial,helvetica" size="-1">
                         <p><b>Dear JASIFY team,</b></p>
-                        <p>A new subscription has been created!</p>
+                        <p>A new subscription has been created for %SubscriberName%!</p>
                     </font>
                         <table cellpadding="4" cellspacing="0" border="0" width="100%">
                             <tr>
@@ -39,67 +39,7 @@
                             <tr>
                                 <td height="148">
                                     <table border="0" cellpadding="1" cellspacing="0" width="100%" align="left">
-                                        <tr>
-                                            <td>
-                                                <p>Order # &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %OrderNumber%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Publisher &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %PublisherName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Subscriber &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %SubscriberName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <br>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Activity &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Start &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityStart%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Finish &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityFinish%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Price &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityPrice%</p>
-                                            </td>
-                                        </tr>
+                                        %ActivityDetails%
                                         <tr>
                                             <td>
                                                 <p>Fees &nbsp;</p>

--- a/schedule/schedule-appengine/src/main/resources/jasify/Subscription.txt
+++ b/schedule/schedule-appengine/src/main/resources/jasify/Subscription.txt
@@ -1,17 +1,9 @@
 Dear JASIFY team,
 
-A new subscription has been created!
+A new subscription has been created for %SubscriberName%
 
 Order Details
-Order        #: %OrderNumber%
-Publisher     : %PublisherName%
-Subscriber    : %SubscriberName%
-
-Activity      : %ActivityName%
-Start         : %ActivityStart%
-Finish        : %ActivityFinish%
-Price         : %ActivityPrice%
-
+%ActivityDetails%
 Fees          : %Fees%
 Tax           : %Tax%
 

--- a/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.html
+++ b/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.html
@@ -1,0 +1,53 @@
+<tr>
+    <td>
+        <p>Order # &nbsp;</p>
+    </td>
+    <td>
+        <p>: %OrderNumber%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Publisher &nbsp;</p>
+    </td>
+    <td>
+        <p>: %PublisherName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Activity &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Start &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityStart%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Finish &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityFinish%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Price &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityPrice%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <br>
+    </td>
+</tr>

--- a/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.txt
+++ b/schedule/schedule-appengine/src/main/resources/jasify/SubscriptionActivityDetails.txt
@@ -1,0 +1,7 @@
+Order        #: %OrderNumber%
+Publisher     : %PublisherName%
+Activity      : %ActivityName%
+Start         : %ActivityStart%
+Finish        : %ActivityFinish%
+Price         : %ActivityPrice%
+

--- a/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.html
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <title>Order of %ActivityName%</title>
+    <title>Subscription Information</title>
 </head>
 <body bgcolor="#FFFFFF" link="#0066CC">
 
@@ -28,57 +28,16 @@
                             <tr>
                                 <td height="148">
                                     <table border="0" cellpadding="1" cellspacing="0" width="100%" align="left">
+                                        %ActivityDetails%
                                         <tr>
-                                            <td>
-                                                <p>Order # &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %OrderNumber%</p>
-                                            </td>
+                                            <td>&nbsp;</td>
                                         </tr>
                                         <tr>
                                             <td>
-                                                <p>Purchased From &nbsp;</p>
+                                                <p><b>Total &nbsp;</b></p>
                                             </td>
                                             <td>
-                                                <p>: %PublisherName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <br>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Activity &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityName%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Start &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityStart%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Finish &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityFinish%</p>
-                                            </td>
-                                        </tr>
-                                        <tr>
-                                            <td>
-                                                <p>Price &nbsp;</p>
-                                            </td>
-                                            <td>
-                                                <p>: %ActivityPrice%</p>
+                                                <p><b>: %TotalPrice%</b></p>
                                             </td>
                                         </tr>
                                     </table>

--- a/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.txt
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/Subscription.txt
@@ -3,12 +3,8 @@ Dear %SubscriberName%,
 Thank you for your order!
 
 Order Details
-Order        #: %OrderNumber%
-Purchased From: %PublisherName%
+%ActivityDetails%
+Total         : %TotalPrice%
 
-Activity      : %ActivityName%
-Start         : %ActivityStart%
-Finish        : %ActivityFinish%
-Price         : %ActivityPrice%
 
 Thank you again for booking with Jasify

--- a/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.html
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.html
@@ -1,0 +1,53 @@
+<tr>
+    <td>
+        <p>Order # &nbsp;</p>
+    </td>
+    <td>
+        <p>: %OrderNumber%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Purchased From &nbsp;</p>
+    </td>
+    <td>
+        <p>: %PublisherName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Activity &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityName%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Start &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityStart%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Finish &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityFinish%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <p>Price &nbsp;</p>
+    </td>
+    <td>
+        <p>: %ActivityPrice%</p>
+    </td>
+</tr>
+<tr>
+    <td>
+        <br>
+    </td>
+</tr>

--- a/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.txt
+++ b/schedule/schedule-appengine/src/main/resources/subscriber/SubscriptionActivityDetails.txt
@@ -1,0 +1,7 @@
+Order        #: %OrderNumber%
+Purchased From: %PublisherName%
+Activity      : %ActivityName%
+Start         : %ActivityStart%
+Finish        : %ActivityFinish%
+Price         : %ActivityPrice%
+

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/mail/MailParserTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/mail/MailParserTest.java
@@ -194,6 +194,7 @@ public class MailParserTest {
         assert(text.contains(": " + activity2.getPrice()));
 
         assert(text.contains(": " + MailParser.formatPrice(activity1.getPrice() + activity2.getPrice())));
+
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityServiceTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityServiceTest.java
@@ -11,7 +11,6 @@ import com.jasify.schedule.appengine.meta.activity.ActivityTypeMeta;
 import com.jasify.schedule.appengine.model.*;
 import com.jasify.schedule.appengine.model.activity.RepeatDetails.*;
 import com.jasify.schedule.appengine.model.common.Organization;
-import com.jasify.schedule.appengine.model.common.OrganizationServiceFactory;
 import com.jasify.schedule.appengine.model.users.User;
 import org.junit.After;
 import org.junit.Before;
@@ -807,31 +806,6 @@ public class ActivityServiceTest {
         List<Subscription> modelList = activity1Organization1.getSubscriptionListRef().getModelList();
         assertEquals(1, modelList.size());
         assertEquals(subscription.getId(), modelList.get(0).getId());
-    }
-
-    @Test
-    public void testSubscribeNotifies() throws Exception {
-        activity1Organization1.setPrice(12.2);
-        OrganizationServiceFactory.getOrganizationService().addUserToOrganization(organization1, testUser2);
-        activityService.addActivity(activity1Organization1, new RepeatDetails());
-        LocalMailService service = LocalMailServiceTestConfig.getLocalMailService();
-        service.clearSentMessages();
-        activityService.subscribe(testUser1, activity1Organization1);
-        List<MailServicePb.MailMessage> sentMessages = service.getSentMessages();
-        assertNotNull(sentMessages);
-        assertEquals(3, sentMessages.size());
-    }
-
-    @Test
-    public void testSubscribeNotifiesIfPriceIsNull() throws Exception {
-        OrganizationServiceFactory.getOrganizationService().addUserToOrganization(organization1, testUser2);
-        activityService.addActivity(activity1Organization1, new RepeatDetails());
-        LocalMailService service = LocalMailServiceTestConfig.getLocalMailService();
-        service.clearSentMessages();
-        activityService.subscribe(testUser1, activity1Organization1);
-        List<MailServicePb.MailMessage> sentMessages = service.getSentMessages();
-        assertNotNull(sentMessages);
-        assertEquals(3, sentMessages.size());
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityServiceTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityServiceTest.java
@@ -225,11 +225,19 @@ public class ActivityServiceTest {
         Key id = activityService.addActivityType(organization1, activityType);
         activityType.setName("New Name");
         activityType.setDescription("Description");
+        activityType.setPrice(55.0);
+        activityType.setCurrency("NZD");
+        activityType.setLocation("Location");
+        activityType.setMaxSubscriptions(6);
         ActivityType updatedActivityType = activityService.updateActivityType(activityType);
         assertNotNull(updatedActivityType);
         assertEquals(id, updatedActivityType.getId());
         assertEquals("New Name", updatedActivityType.getName());
         assertEquals("Description", updatedActivityType.getDescription());
+        assertEquals(55.0, updatedActivityType.getPrice());
+        assertEquals("NZD", updatedActivityType.getCurrency());
+        assertEquals("Location", updatedActivityType.getLocation());
+        assertEquals(6, updatedActivityType.getMaxSubscriptions());
         assertEquals("New Name", activityService.getActivityType(id).getName());
     }
 

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityTypeTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/activity/ActivityTypeTest.java
@@ -10,6 +10,7 @@ import org.slim3.datastore.Datastore;
 import java.util.Date;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNull;
 
 /**
  * @author wszarmach
@@ -75,6 +76,8 @@ public class ActivityTypeTest {
     @Test
     public void testLcNameDoesNotChangeName() {
         ActivityType activityType = new ActivityType();
+        assertNull(activityType.getName());
+        assertNull(activityType.getLcName());
         activityType.setName("Test1");
         assertEquals("Test1", activityType.getLcName());
         activityType.setLcName("Test2");
@@ -85,7 +88,40 @@ public class ActivityTypeTest {
     @Test
     public void testDescription() {
         ActivityType activityType = new ActivityType();
+        assertNull(activityType.getDescription());
         activityType.setDescription("Fun");
         assertEquals("Fun", activityType.getDescription());
+    }
+
+    @Test
+    public void testPrice() {
+        ActivityType activityType = new ActivityType();
+        assertNull(activityType.getPrice());
+        activityType.setPrice(15.0);
+        assertEquals(15.0, activityType.getPrice());
+    }
+
+    @Test
+    public void testCurrency() {
+        ActivityType activityType = new ActivityType();
+        assertNull(activityType.getCurrency());
+        activityType.setCurrency("NZD");
+        assertEquals("NZD", activityType.getCurrency());
+    }
+
+    @Test
+    public void testLocation() {
+        ActivityType activityType = new ActivityType();
+        assertNull(activityType.getLocation());
+        activityType.setLocation("Location");
+        assertEquals("Location", activityType.getLocation());
+    }
+
+    @Test
+    public void testMaxSubscriptions() {
+        ActivityType activityType = new ActivityType();
+        assertEquals(0, activityType.getMaxSubscriptions());
+        activityType.setMaxSubscriptions(12);
+        assertEquals(12, activityType.getMaxSubscriptions());
     }
 }

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
@@ -102,8 +102,12 @@ public class ShoppingCartPaymentWorkflowTest {
         TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
         try {
             testShoppingCartServiceFactory.setUp();
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
+
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
+                    .andReturn(new ShoppingCart(SOME_CART));
+
             testShoppingCartServiceFactory.replay();
+
             PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Completed);
         } finally {
             testShoppingCartServiceFactory.tearDown();
@@ -112,7 +116,6 @@ public class ShoppingCartPaymentWorkflowTest {
 
     @Test
     public void testOnCompletedSendsEmails() throws Exception {
-        // This test looks too big :(
         ActivityPaymentWorkflow activityPaymentWorkflow1 = createActivityPaymentWorkflow();
         Subscription subscription1 = createSubscription();
         activityPaymentWorkflow1.setSubscriptionId(subscription1.getId());
@@ -140,7 +143,9 @@ public class ShoppingCartPaymentWorkflowTest {
 
             EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription1.getId())).andReturn(subscription1);
             EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription2.getId())).andReturn(subscription2);
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
+
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
+                    .andReturn(new ShoppingCart(SOME_CART));
 
             testShoppingCartServiceFactory.replay();
             testActivityServiceFactory.replay();

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/payment/workflow/ShoppingCartPaymentWorkflowTest.java
@@ -1,19 +1,69 @@
 package com.jasify.schedule.appengine.model.payment.workflow;
 
-import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.mail.MailServicePb;
+import com.google.appengine.api.mail.dev.LocalMailService;
+import com.google.appengine.tools.development.testing.LocalMailServiceTestConfig;
 import com.jasify.schedule.appengine.TestHelper;
+import com.jasify.schedule.appengine.model.activity.*;
 import com.jasify.schedule.appengine.model.cart.ShoppingCart;
 import com.jasify.schedule.appengine.model.cart.TestShoppingCartServiceFactory;
-import com.jasify.schedule.appengine.model.payment.PaymentStateEnum;
+import com.jasify.schedule.appengine.model.common.Organization;
+import com.jasify.schedule.appengine.model.common.OrganizationMember;
+import com.jasify.schedule.appengine.model.payment.*;
+import com.jasify.schedule.appengine.model.users.User;
 import org.easymock.EasyMock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.slim3.datastore.Datastore;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
 public class ShoppingCartPaymentWorkflowTest {
     public static final String SOME_CART = "someCart";
-    private Key workflowId;
+
+    private PayPalPayment newPayment(List<PaymentWorkflow> workflows) throws PaymentException {
+        PayPalPayment payment = new PayPalPayment();
+        payment.setCurrency("USD");
+        payment.setAmount(30.35);
+        PaymentService paymentService = PaymentServiceFactory.getPaymentService();
+        paymentService.newPayment(Datastore.allocateId(User.class), payment, workflows);
+        return payment;
+    }
+
+    private User createUser() {
+        User user = new User();
+        user.setRealName("Real Name");
+        user.setName("Name");
+        user.setEmail("Em@il.com");
+        Datastore.put(user);
+        return user;
+    }
+
+    private Subscription createSubscription() throws Exception {
+        Organization organization = new Organization("Org");
+        organization.setId(Datastore.allocateId(Organization.class));
+        Datastore.put(new OrganizationMember(organization, createUser()));
+        ActivityType activityType = new ActivityType("AT");
+        activityType.getOrganizationRef().setModel(organization);
+        Activity activity = new Activity(activityType);
+        Subscription subscription = new Subscription();
+        subscription.setId(Datastore.allocateId(Subscription.class));
+        subscription.getActivityRef().setModel(activity);
+        subscription.getUserRef().setModel(createUser());
+        return subscription;
+    }
+
+    private ActivityPaymentWorkflow createActivityPaymentWorkflow() {
+        ActivityPaymentWorkflow activityPaymentWorkflow = new ActivityPaymentWorkflow();
+        Datastore.put(activityPaymentWorkflow);
+        return activityPaymentWorkflow;
+    }
 
     @Before
     public void setup() {
@@ -30,7 +80,6 @@ public class ShoppingCartPaymentWorkflowTest {
         //no op
         ShoppingCartPaymentWorkflow workflow = new ShoppingCartPaymentWorkflow(SOME_CART);
         Datastore.put(workflow);
-        workflowId = workflow.getId();
         PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Created);
     }
 
@@ -44,19 +93,69 @@ public class ShoppingCartPaymentWorkflowTest {
 
     @Test
     public void testOnCompleted() throws Exception {
-        testOnCreated();
+        ShoppingCartPaymentWorkflow workflow = new ShoppingCartPaymentWorkflow(SOME_CART);
+        Datastore.put(workflow);
+
+        newPayment(Arrays.asList(new PaymentWorkflow[]{workflow}));
+
+        PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Created);
         TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
         try {
             testShoppingCartServiceFactory.setUp();
-
-            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART))
-                    .andReturn(new ShoppingCart(SOME_CART));
-
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
             testShoppingCartServiceFactory.replay();
-
-            PaymentWorkflowEngine.transition(workflowId, PaymentStateEnum.Completed);
+            PaymentWorkflowEngine.transition(workflow.getId(), PaymentStateEnum.Completed);
         } finally {
             testShoppingCartServiceFactory.tearDown();
+        }
+    }
+
+    @Test
+    public void testOnCompletedSendsEmails() throws Exception {
+        // This test looks too big :(
+        ActivityPaymentWorkflow activityPaymentWorkflow1 = createActivityPaymentWorkflow();
+        Subscription subscription1 = createSubscription();
+        activityPaymentWorkflow1.setSubscriptionId(subscription1.getId());
+
+        ActivityPaymentWorkflow activityPaymentWorkflow2 = createActivityPaymentWorkflow();
+        Subscription subscription2 = createSubscription();
+        activityPaymentWorkflow2.setSubscriptionId(subscription2.getId());
+
+        ShoppingCartPaymentWorkflow shoppingCartPaymentWorkflow = new ShoppingCartPaymentWorkflow(SOME_CART);
+        Datastore.put(shoppingCartPaymentWorkflow);
+
+        List<PaymentWorkflow> workflows = new ArrayList<>();
+        workflows.add(activityPaymentWorkflow1);
+        workflows.add(activityPaymentWorkflow2);
+        workflows.add(shoppingCartPaymentWorkflow);
+        newPayment(workflows);
+
+        PaymentWorkflowEngine.transition(shoppingCartPaymentWorkflow.getId(), PaymentStateEnum.Created);
+        TestShoppingCartServiceFactory testShoppingCartServiceFactory = new TestShoppingCartServiceFactory();
+        TestActivityServiceFactory testActivityServiceFactory = new TestActivityServiceFactory();
+
+        try {
+            testShoppingCartServiceFactory.setUp();
+            testActivityServiceFactory.setUp();
+
+            EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription1.getId())).andReturn(subscription1);
+            EasyMock.expect(testActivityServiceFactory.getActivityServiceMock().getSubscription(subscription2.getId())).andReturn(subscription2);
+            EasyMock.expect(testShoppingCartServiceFactory.getShoppingCartServiceMock().clearCart(SOME_CART)).andReturn(new ShoppingCart(SOME_CART));
+
+            testShoppingCartServiceFactory.replay();
+            testActivityServiceFactory.replay();
+
+            LocalMailService localMailService = LocalMailServiceTestConfig.getLocalMailService();
+            localMailService.clearSentMessages();
+
+            PaymentWorkflowEngine.transition(shoppingCartPaymentWorkflow.getId(), PaymentStateEnum.Completed);
+            List<MailServicePb.MailMessage> sentMessages = localMailService.getSentMessages();
+            assertNotNull(sentMessages);
+            // One for Jasify, One for Subscriber, Two for Publisher
+            assertEquals(4, sentMessages.size());
+        } finally {
+            testShoppingCartServiceFactory.tearDown();
+            testActivityServiceFactory.tearDown();
         }
     }
 }

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/transform/JasActivityTypeTransformerTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/transform/JasActivityTypeTransformerTest.java
@@ -38,10 +38,18 @@ public class JasActivityTypeTransformerTest {
         internal.getOrganizationRef().setKey(orgId);
         internal.setName("activity");
         internal.setDescription("Desc");
+        internal.setPrice(12.0);
+        internal.setCurrency("NZD");
+        internal.setLocation("Location");
+        internal.setMaxSubscriptions(5);
         JasActivityType external = transformer.transformTo(internal);
         assertNotNull(external);
         assertEquals("activity", external.getName());
         assertEquals("Desc", external.getDescription());
+        assertEquals(12.0, external.getPrice());
+        assertEquals("NZD", external.getCurrency());
+        assertEquals("Location", external.getLocation());
+        assertEquals(5, external.getMaxSubscriptions());
         assertEquals(id, KeyUtil.stringToKey(external.getId()));
         assertNotNull(external.getOrganizationId());
         assertEquals(orgId, new JasKeyTransformer().transformFrom(external.getOrganizationId()));
@@ -54,10 +62,18 @@ public class JasActivityTypeTransformerTest {
         external.setId(KeyUtil.keyToString(id));
         external.setName("activity");
         external.setDescription("Desc");
+        external.setPrice(12.0);
+        external.setCurrency("NZD");
+        external.setLocation("Location");
+        external.setMaxSubscriptions(5);
         ActivityType internal = transformer.transformFrom(external);
         assertNotNull(internal);
         assertEquals("activity", internal.getName());
         assertEquals("Desc", internal.getDescription());
+        assertEquals(12.0, internal.getPrice());
+        assertEquals("NZD", internal.getCurrency());
+        assertEquals("Location", internal.getLocation());
+        assertEquals(5, internal.getMaxSubscriptions());
         assertEquals(id, internal.getId());
     }
 }


### PR DESCRIPTION
This PR should be viewed/done after my email-subscription PR.

Fixes #231 
* Added new fields to ActivityType, Price,  Currency,  Location, MaxSubscriptions. These will now correctly auto populate a new Activity but will not override an the Activity values during an update (this was a previously not detected bug).
* Added the new fields to the new ActivityType form. Had to increase the label columns to fit the subcriptions(max) label.