### PR TITLE
LocalDatastoreService creates an executor and adds a "shutdown hook" …

### DIFF
--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/TestHelper.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/TestHelper.java
@@ -1,6 +1,7 @@
 package com.jasify.schedule.appengine;
 
 import com.google.appengine.api.datastore.ShortBlob;
+import com.google.appengine.api.datastore.dev.LocalDatastoreService;
 import com.google.appengine.tools.development.testing.*;
 import com.google.common.base.Throwables;
 import com.jasify.schedule.appengine.meta.users.UserMeta;
@@ -167,6 +168,7 @@ public final class TestHelper {
     }
 
     public static void cleanupDatastore(LocalServiceTestHelper datastoreHelper) {
+        LocalDatastoreServiceTestConfig.getLocalDatastoreService().stop();
         datastoreHelper.tearDown();
         DatastoreUtil.clearKeysCache();
         DatastoreUtil.clearActiveGlobalTransactions();


### PR DESCRIPTION
… to stop it.  Since mvn runs each test in a new thread, this creates many of these executors and exhausts the OSX maximum number of threads.  I added a method to "run" the shutdown hook and this fixes #474