### PR TITLE
Org dao endpoints

### DIFF
--- a/schedule/schedule-appengine/src/main/client/jasify/admin/admin.routes.js
+++ b/schedule/schedule-appengine/src/main/client/jasify/admin/admin.routes.js
@@ -260,7 +260,7 @@
 
                         var dfd = $q.defer();
 
-                        Allow.admin().then(
+                        Allow.adminOrOrgMember().then(
                             function () {
                                 Organization.query().then(function (result) {
                                     if ($route.current.params.organizationId) {
@@ -283,7 +283,7 @@
                     },
                     activityTypes: /*@ngInject*/ function ($q, $route, Allow, ActivityType) {
 
-                        return Allow.admin().then(allowed, forbidden);
+                        return Allow.adminOrOrgMember().then(allowed, forbidden);
 
                         function allowed() {
                             if ($route.current.params.organizationId) {
@@ -312,7 +312,7 @@
                 controllerAs: 'vm',
                 resolve: {
                     organizations: /*@ngInject*/ function ($q, Allow, Organization) {
-                        return Allow.admin().then(
+                        return Allow.adminOrOrgMember().then(
                             function () {
                                 return Organization.query();
                             },
@@ -323,7 +323,7 @@
                     },
                     activityType: /*@ngInject*/ function ($q, $route, Allow, ActivityType) {
 
-                        return Allow.admin().then(allowed, forbidden);
+                        return Allow.adminOrOrgMember().then(allowed, forbidden);
 
                         function allowed() {
                             if ($route.current.params.id) {

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/dao/common/OrganizationDao.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/dao/common/OrganizationDao.java
@@ -79,8 +79,8 @@ public class OrganizationDao extends BaseCachingDao<Organization> {
         });
     }
 
-    public List<Organization> forUser(User user) throws EntityNotFoundException {
-        return forUser(user.getId());
+    public List<Organization> forUser(long userId) throws EntityNotFoundException {
+        return forUser(Datastore.createKey(User.class, userId));
     }
 
     public List<Organization> forUser(Key userId) throws EntityNotFoundException {

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/HasId.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/HasId.java
@@ -1,0 +1,15 @@
+package com.jasify.schedule.appengine.model;
+
+import com.google.appengine.api.datastore.Key;
+
+/**
+ * Interface for model entities that have <code>private Key id</code> as their primary key.
+ *
+ * @author krico
+ * @since 11/06/15.
+ */
+public interface HasId {
+
+    Key getId();
+
+}

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/common/Organization.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/common/Organization.java
@@ -2,6 +2,7 @@ package com.jasify.schedule.appengine.model.common;
 
 import com.google.appengine.api.datastore.Key;
 import com.jasify.schedule.appengine.meta.common.OrganizationMemberMeta;
+import com.jasify.schedule.appengine.model.HasId;
 import com.jasify.schedule.appengine.model.LowerCaseListener;
 import com.jasify.schedule.appengine.model.payment.PaymentTypeEnum;
 import com.jasify.schedule.appengine.model.users.User;
@@ -16,7 +17,7 @@ import java.util.*;
  * @since 08/01/15.
  */
 @Model
-public class Organization {
+public class Organization implements HasId {
     private static final Logger log = LoggerFactory.getLogger(Organization.class);
 
     @Attribute(primaryKey = true)

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/common/OrganizationMember.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/common/OrganizationMember.java
@@ -1,6 +1,7 @@
 package com.jasify.schedule.appengine.model.common;
 
 import com.google.appengine.api.datastore.Key;
+import com.jasify.schedule.appengine.model.HasId;
 import com.jasify.schedule.appengine.model.users.User;
 import org.slim3.datastore.Attribute;
 import org.slim3.datastore.Model;
@@ -13,7 +14,7 @@ import org.slim3.datastore.ModelRef;
  * @since 08/01/15.
  */
 @Model
-public class OrganizationMember {
+public class OrganizationMember implements HasId {
     @Attribute(primaryKey = true)
     private Key id;
 

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/ActivityEndpoint.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/ActivityEndpoint.java
@@ -77,7 +77,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityTypes.get", path = "activity-types/{id}", httpMethod = ApiMethod.HttpMethod.GET)
     public ActivityType getActivityType(User caller, @Named("id") Key id) throws NotFoundException, UnauthorizedException, ForbiddenException {
-        mustBeAdminOrOrgMember(caller, createFromActivityTypeId(id));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityTypeId(id));
         checkFound(id);
         try {
             return ActivityServiceFactory.getActivityService().getActivityType(id);
@@ -88,7 +88,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityTypes.update", path = "activity-types/{id}", httpMethod = ApiMethod.HttpMethod.PUT)
     public ActivityType updateActivityType(User caller, @Named("id") Key id, ActivityType activityType) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityTypeId(id));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityTypeId(id));
         checkFound(id);
         activityType.setId(id);
         try {
@@ -102,7 +102,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityTypes.add", path = "activity-types", httpMethod = ApiMethod.HttpMethod.POST)
     public ActivityType addActivityType(User caller, JasAddActivityTypeRequest request) throws UnauthorizedException, ForbiddenException, BadRequestException, NotFoundException {
-        mustBeAdminOrOrgMember(caller, createFromOrganizationId(request.getOrganizationId()));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromOrganizationId(request.getOrganizationId()));
         checkFound(request.getActivityType());
         checkFound(request.getOrganizationId());
         Key id;
@@ -126,7 +126,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityTypes.remove", path = "activity-types/{id}", httpMethod = ApiMethod.HttpMethod.DELETE)
     public void removeActivityType(User caller, @Named("id") Key id) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityTypeId(id));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityTypeId(id));
         checkFound(id);
         try {
             // Check if the ActivityType has linked Activities
@@ -257,7 +257,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activities.update", path = "activities/{id}", httpMethod = ApiMethod.HttpMethod.PUT)
     public Activity updateActivity(User caller, @Named("id") Key id, Activity activity) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityId(activity.getId()));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityId(activity.getId()));
         checkFound(id);
         activity.setId(id);
         // In case client does not set the Name field we force the set here
@@ -279,7 +279,7 @@ public class ActivityEndpoint {
         checkFound(request.getActivity().getActivityTypeRef());
         checkFound(request.getActivity().getActivityTypeRef().getKey());
         checkFound(request.getActivity().getActivityTypeRef().getModel());
-        mustBeAdminOrOrgMember(caller, createFromActivityTypeId(request.getActivity().getActivityTypeRef().getKey()));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityTypeId(request.getActivity().getActivityTypeRef().getKey()));
 
         try {
             ActivityService activityService = ActivityServiceFactory.getActivityService();
@@ -303,7 +303,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activities.remove", path = "activities/{id}", httpMethod = ApiMethod.HttpMethod.DELETE)
     public void removeActivity(User caller, @Named("id") Key id) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityId(id));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityId(id));
         checkFound(id);
         try {
             ActivityService activityService = ActivityServiceFactory.getActivityService();
@@ -324,7 +324,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activitySubscriptions.add", path = "activity-subscriptions", httpMethod = ApiMethod.HttpMethod.POST)
     public Subscription addSubscription(User caller, @Named("userId") Key userId, @Named("activityId") Key activityId) throws UnauthorizedException, ForbiddenException, NotFoundException, BadRequestException {
-        mustBeSameUserOrAdminOrOrgMember(caller, userId, createFromActivityId(activityId));
+        mustBeSameUserOrAdminOrOrgMember(caller, userId, OrgMemberChecker.createFromActivityId(activityId));
         checkFound(userId);
         checkFound(activityId);
         ActivityService activityService = ActivityServiceFactory.getActivityService();
@@ -343,7 +343,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activitySubscriptions.query", path = "activity-subscriptions", httpMethod = ApiMethod.HttpMethod.GET)
     public Subscription getSubscription(User caller, @Named("userId") Key userId, @Named("activityId") Key activityId) throws UnauthorizedException, ForbiddenException, NotFoundException, BadRequestException {
-        mustBeSameUserOrAdminOrOrgMember(caller, userId, createFromActivityId(activityId));
+        mustBeSameUserOrAdminOrOrgMember(caller, userId, OrgMemberChecker.createFromActivityId(activityId));
         checkFound(userId);
         checkFound(activityId);
         try {
@@ -363,7 +363,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activitySubscriptions.subscribers", path = "activities/{id}/subscribers", httpMethod = ApiMethod.HttpMethod.GET)
     public List<Subscription> getSubscriptions(User caller, @Named("activityId") Key activityId) throws UnauthorizedException, ForbiddenException, NotFoundException {
-        mustBeAdminOrOrgMember(caller, createFromActivityId(activityId));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityId(activityId));
         checkFound(activityId);
         try {
             Activity activity = ActivityServiceFactory.getActivityService().getActivity(activityId);
@@ -375,7 +375,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activitySubscriptions.cancel", path = "activities/{id}/subscribers", httpMethod = ApiMethod.HttpMethod.DELETE)
     public void cancelSubscription(User caller, @Named("subscriptionId") Key subscriptionId) throws UnauthorizedException, ForbiddenException, NotFoundException {
-        mustBeAdminOrOrgMember(caller, createFromSubscriptionId(subscriptionId));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromSubscriptionId(subscriptionId));
         checkFound(subscriptionId);
         try {
             ActivityServiceFactory.getActivityService().cancelSubscription(subscriptionId);
@@ -407,7 +407,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityPackages.update", path = "activity-packages/{id}", httpMethod = ApiMethod.HttpMethod.PUT)
     public ActivityPackage updateActivityPackage(User caller, @Named("id") Key id, JasActivityPackageRequest request) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityPackageId(id));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityPackageId(id));
         checkFound(id);
         ActivityPackage activityPackage = Preconditions.checkNotNull(request.getActivityPackage(), "request.ActivityPackage is NULL");
         List<Activity> activities = Preconditions.checkNotNull(request.getActivities(), "request.Activities is NULL");
@@ -430,7 +430,7 @@ public class ActivityEndpoint {
         if (activities.isEmpty())
             throw new BadRequestException("request.activities.isEmpty");
 
-        mustBeAdminOrOrgMember(caller, createFromOrganizationId(organizationId));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromOrganizationId(organizationId));
 
         ActivityService activityService = ActivityServiceFactory.getActivityService();
         try {
@@ -445,7 +445,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityPackages.remove", path = "activity-packages/{id}", httpMethod = ApiMethod.HttpMethod.DELETE)
     public void removeActivityPackage(User caller, @Named("id") Key id) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityTypeId(id));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityTypeId(id));
         checkFound(id);
         try {
             ActivityServiceFactory.getActivityService().removeActivityPackage(id);
@@ -469,7 +469,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityPackages.addActivity", path = "activity-packages-activity/{activityPackageId}/{activityId}", httpMethod = ApiMethod.HttpMethod.POST)
     public void addActivityToActivityPackage(User caller, @Named("activityPackageId") Key activityPackageId, @Named("activityId") Key activityId) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityPackageId(activityPackageId));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityPackageId(activityPackageId));
         checkFound(activityPackageId);
         checkFound(activityId);
         try {
@@ -484,7 +484,7 @@ public class ActivityEndpoint {
 
     @ApiMethod(name = "activityPackages.removeActivity", path = "activity-packages-activity/{activityPackageId}/{activityId}", httpMethod = ApiMethod.HttpMethod.DELETE)
     public void removeActivityFromActivityPackage(User caller, @Named("activityPackageId") Key activityPackageId, @Named("activityId") Key activityId) throws NotFoundException, UnauthorizedException, ForbiddenException, BadRequestException {
-        mustBeAdminOrOrgMember(caller, createFromActivityPackageId(activityPackageId));
+        mustBeAdminOrOrgMember(caller, OrgMemberChecker.createFromActivityPackageId(activityPackageId));
         checkFound(activityPackageId);
         checkFound(activityId);
         try {

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/JasifyEndpoint.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/JasifyEndpoint.java
@@ -10,7 +10,6 @@ import com.jasify.schedule.appengine.model.EntityNotFoundException;
 import com.jasify.schedule.appengine.model.activity.*;
 import com.jasify.schedule.appengine.model.common.Organization;
 import com.jasify.schedule.appengine.model.common.OrganizationServiceFactory;
-import com.jasify.schedule.appengine.model.users.UserServiceFactory;
 import com.jasify.schedule.appengine.spi.auth.JasifyAuthenticator;
 import com.jasify.schedule.appengine.spi.auth.JasifyEndpointUser;
 import com.jasify.schedule.appengine.spi.dm.JasApiInfo;
@@ -46,70 +45,6 @@ import com.jasify.schedule.appengine.spi.transform.*;
                 ownerName = "Jasify",
                 packagePath = ""))
 public class JasifyEndpoint {
-    abstract static class OrgMemberChecker {
-        protected final Key id;
-        protected OrgMemberChecker(Key id) {
-            this.id = id;
-        }
-        public boolean isOrgMember(long userId) throws EntityNotFoundException {
-            Organization organization = getOrganization();
-            com.jasify.schedule.appengine.model.users.User user = UserServiceFactory.getUserService().get(userId);
-            return organization.getUsers().contains(user);
-        }
-        abstract Organization getOrganization() throws EntityNotFoundException;
-    }
-
-    static OrgMemberChecker createFromActivityId(Key id) {
-        return new OrgMemberChecker(id) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                Activity activity = ActivityServiceFactory.getActivityService().getActivity(this.id);
-                ActivityType activityType = activity.getActivityTypeRef().getModel();
-                return activityType.getOrganizationRef().getModel();
-            }
-        };
-    }
-
-    static OrgMemberChecker createFromActivityTypeId(Key id) {
-        return new OrgMemberChecker(id) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                ActivityType activityType = ActivityServiceFactory.getActivityService().getActivityType(this.id);
-                return activityType.getOrganizationRef().getModel();
-            }
-        };
-    }
-
-    static OrgMemberChecker createFromActivityPackageId(Key id) {
-        return new OrgMemberChecker(id) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                ActivityPackage activityPackage = ActivityServiceFactory.getActivityService().getActivityPackage(this.id);
-                return activityPackage.getOrganizationRef().getModel();
-            }
-        };
-    }
-
-    static OrgMemberChecker createFromSubscriptionId(Key id) {
-        return new OrgMemberChecker(id) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                Subscription subscription = ActivityServiceFactory.getActivityService().getSubscription(this.id);
-                Activity activity = subscription.getActivityRef().getModel();
-                ActivityType activityType = activity.getActivityTypeRef().getModel();
-                return activityType.getOrganizationRef().getModel();
-            }
-        };
-    }
-
-    static OrgMemberChecker createFromOrganizationId(Key id) {
-        return new OrgMemberChecker(id) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                return OrganizationServiceFactory.getOrganizationService().getOrganization(this.id);
-            }
-        };
-    }
 
     static JasifyEndpointUser mustBeLoggedIn(User caller) throws UnauthorizedException {
         if (caller instanceof JasifyEndpointUser) return (JasifyEndpointUser) caller;

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/OrgMemberChecker.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/OrgMemberChecker.java
@@ -1,0 +1,153 @@
+package com.jasify.schedule.appengine.spi;
+
+import com.google.appengine.api.datastore.Key;
+import com.jasify.schedule.appengine.dao.common.OrganizationDao;
+import com.jasify.schedule.appengine.model.EntityNotFoundException;
+import com.jasify.schedule.appengine.model.activity.*;
+import com.jasify.schedule.appengine.model.common.Organization;
+import com.jasify.schedule.appengine.model.users.UserServiceFactory;
+
+/**
+ * @author krico
+ * @since 11/06/15.
+ */
+abstract class OrgMemberChecker {
+    private static final OrgMemberChecker FALSE = new OrgMemberChecker() {
+        @Override
+        Organization getOrganization() throws EntityNotFoundException {
+            return null;
+        }
+
+        @Override
+        public boolean isOrgMember(long userId) throws EntityNotFoundException {
+            return false;
+        }
+    };
+    private static final OrgMemberChecker NOT_FOUND = new OrgMemberChecker() {
+        @Override
+        Organization getOrganization() throws EntityNotFoundException {
+            throw new EntityNotFoundException();
+        }
+    };
+    private final OrganizationDao organizationDao = new OrganizationDao();
+    protected Key id;
+    private static final ThreadLocal<OrgMemberChecker> ACTIVITY = new ThreadLocal<OrgMemberChecker>() {
+        @Override
+        protected OrgMemberChecker initialValue() {
+            return new OrgMemberChecker() {
+                @Override
+                Organization getOrganization() throws EntityNotFoundException {
+                    Activity activity = ActivityServiceFactory.getActivityService().getActivity(id);
+                    ActivityType activityType = activity.getActivityTypeRef().getModel();
+                    return getOrganization(activityType.getOrganizationRef().getKey());
+                }
+            };
+        }
+    };
+
+    private static final ThreadLocal<OrgMemberChecker> ACTIVITY_TYPE = new ThreadLocal<OrgMemberChecker>() {
+        @Override
+        protected OrgMemberChecker initialValue() {
+            return new OrgMemberChecker() {
+                @Override
+                Organization getOrganization() throws EntityNotFoundException {
+                    ActivityType activityType = ActivityServiceFactory.getActivityService().getActivityType(id);
+                    return getOrganization(activityType.getOrganizationRef().getKey());
+                }
+            };
+        }
+    };
+
+    private static final ThreadLocal<OrgMemberChecker> ACTIVITY_PACKAGE = new ThreadLocal<OrgMemberChecker>() {
+        @Override
+        protected OrgMemberChecker initialValue() {
+            return new OrgMemberChecker() {
+                @Override
+                Organization getOrganization() throws EntityNotFoundException {
+                    ActivityPackage activityPackage = ActivityServiceFactory.getActivityService().getActivityPackage(id);
+                    return getOrganization(activityPackage.getOrganizationRef().getKey());
+                }
+            };
+        }
+    };
+
+    private static final ThreadLocal<OrgMemberChecker> SUBSCRIPTION = new ThreadLocal<OrgMemberChecker>() {
+        @Override
+        protected OrgMemberChecker initialValue() {
+            return new OrgMemberChecker() {
+                @Override
+                Organization getOrganization() throws EntityNotFoundException {
+                    Subscription subscription = ActivityServiceFactory.getActivityService().getSubscription(id);
+                    Activity activity = subscription.getActivityRef().getModel();
+                    ActivityType activityType = activity.getActivityTypeRef().getModel();
+                    return getOrganization(activityType.getOrganizationRef().getKey());
+                }
+            };
+        }
+    };
+
+    private static final ThreadLocal<OrgMemberChecker> ORGANIZATION = new ThreadLocal<OrgMemberChecker>() {
+        @Override
+        protected OrgMemberChecker initialValue() {
+            return new OrgMemberChecker() {
+                @Override
+                Organization getOrganization() throws EntityNotFoundException {
+                    return getOrganization(id);
+                }
+            };
+        }
+    };
+
+    private OrgMemberChecker() {
+    }
+
+    private OrgMemberChecker(Key id) {
+        this.id = id;
+    }
+
+    public static OrgMemberChecker createFromActivityId(Key id) {
+        return ACTIVITY.get().withId(id);
+    }
+
+    public static OrgMemberChecker createFromActivityTypeId(Key id) {
+        return ACTIVITY_TYPE.get().withId(id);
+    }
+
+    public static OrgMemberChecker createFromActivityPackageId(Key id) {
+        return ACTIVITY_PACKAGE.get().withId(id);
+    }
+
+    public static OrgMemberChecker createFromSubscriptionId(Key id) {
+        return SUBSCRIPTION.get().withId(id);
+    }
+
+    public static OrgMemberChecker createFromOrganizationId(Key id) {
+        return ORGANIZATION.get().withId(id);
+    }
+
+    public static OrgMemberChecker createFalse() {
+        return FALSE;
+    }
+
+    public static OrgMemberChecker createNotFound() {
+        return NOT_FOUND;
+    }
+
+    public OrgMemberChecker withId(Key id) {
+        this.id = id;
+        return this;
+    }
+
+    public boolean isOrgMember(long userId) throws EntityNotFoundException {
+        Organization organization = getOrganization();
+        com.jasify.schedule.appengine.model.users.User user = UserServiceFactory.getUserService().get(userId);
+        return organization.getUsers().contains(user);
+    }
+
+    protected Organization getOrganization(Key id) throws EntityNotFoundException {
+        if (id == null) return null;
+        return organizationDao.get(id);
+    }
+
+    abstract Organization getOrganization() throws EntityNotFoundException;
+}

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/OrganizationEndpoint.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/OrganizationEndpoint.java
@@ -64,12 +64,13 @@ public class OrganizationEndpoint {
     public List<Organization> getOrganizations(User caller) throws UnauthorizedException, ForbiddenException, EntityNotFoundException {
         JasifyEndpointUser jasUser = mustBeLoggedIn(caller);
         // Admin sees all
-        if (jasUser.isAdmin()) return organizationDao.getAll();
+        if (jasUser.isAdmin()) {
+            return organizationDao.getAll();
+        }
         if (jasUser.isOrgMember()) {
-            return OrganizationServiceFactory.getOrganizationService().getOrganizationsForUser(jasUser.getUserId());
+            return organizationDao.forUser(jasUser.getUserId());
         }
         throw new ForbiddenException("Must be admin");
-
     }
 
     @ApiMethod(name = "organizations.get", path = "organizations/{id}", httpMethod = ApiMethod.HttpMethod.GET)

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/ShoppingCartEndpoint.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/ShoppingCartEndpoint.java
@@ -139,7 +139,7 @@ public class ShoppingCartEndpoint {
         ShoppingCartService cartService = ShoppingCartServiceFactory.getShoppingCartService();
         return cartService.addItem(cartId, new ShoppingCart.ItemBuilder()
                 .activityPackage(activityPackage)
-                .data(new ArrayList<Key>(uniqueKeys))
+                .data(new ArrayList<>(uniqueKeys))
                 .build())
                 .calculate();
     }

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/AssertionHelper.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/AssertionHelper.java
@@ -1,0 +1,44 @@
+package com.jasify.schedule.appengine;
+
+import com.google.appengine.api.datastore.Key;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.jasify.schedule.appengine.model.HasId;
+
+import javax.annotation.Nullable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
+
+/**
+ * @author krico
+ * @since 11/06/15.
+ */
+public final class AssertionHelper {
+    private AssertionHelper() {
+    }
+
+    public static <T extends HasId> void assertIdsEqual(List<T> expected, List<T> real) {
+        assertNotNull("expected is NULL", expected);
+        assertNotNull("real is NULL", real);
+        assertEquals("expected.size != real.size", expected.size(), real.size());
+
+        Function<T, Key> toKey = new Function<T, Key>() {
+            @Nullable
+            @Override
+            public Key apply(T t) {
+                return t.getId();
+            }
+        };
+        List<Key> expectedKeys = new ArrayList<>(Lists.transform(expected, toKey));
+        List<Key> realKeys = new ArrayList<>(Lists.transform(real, toKey));
+        Collections.sort(expectedKeys);
+        Collections.sort(realKeys);
+        for (int i = 0; i < expectedKeys.size(); ++i) {
+            assertEquals("key[" + i + "]", expectedKeys.get(i), realKeys.get(i));
+        }
+    }
+}

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/AssertionHelperTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/AssertionHelperTest.java
@@ -1,0 +1,89 @@
+package com.jasify.schedule.appengine;
+
+import com.google.appengine.api.datastore.Key;
+import com.jasify.schedule.appengine.model.HasId;
+import junit.framework.AssertionFailedError;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slim3.datastore.Datastore;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.jasify.schedule.appengine.AssertionHelper.assertIdsEqual;
+
+public class AssertionHelperTest {
+
+    @BeforeClass
+    public static void datastore() {
+        TestHelper.initializeDatastore();
+    }
+
+    @AfterClass
+    public static void cleanup() {
+        TestHelper.cleanupDatastore();
+    }
+
+    @Test
+    public void testAssertIdsEqualSameOrder() throws Exception {
+        List<Sample> expected = new ArrayList<>();
+        List<Sample> real = new ArrayList<>();
+        for (int i = 0; i < 20; ++i) {
+            Sample sample = new Sample(Datastore.allocateId("Sample"));
+            expected.add(sample);
+            real.add(new Sample(sample.getId()));
+        }
+
+        assertIdsEqual(expected, real);
+    }
+
+    @Test
+    public void testAssertIdsEqualReverse() throws Exception {
+        List<Sample> expected = new ArrayList<>();
+        for (int i = 0; i < 20; ++i) {
+            expected.add(new Sample(Datastore.allocateId("Sample")));
+        }
+
+        List<Sample> real = new ArrayList<>();
+
+        for (int i = 0; i < expected.size(); ++i) {
+            real.add(expected.get(expected.size() - 1 - i));
+        }
+        assertIdsEqual(expected, real);
+    }
+
+    @Test
+    public void testAssertIdsEqualEmpty() throws Exception {
+        List<Sample> expected = new ArrayList<>();
+        List<Sample> real = new ArrayList<>();
+        assertIdsEqual(expected, real);
+    }
+
+    @Test(expected = AssertionFailedError.class)
+    public void testAssertIdsEqualDifferent() throws Exception {
+        List<Sample> expected = new ArrayList<>();
+        List<Sample> real = new ArrayList<>();
+        expected.add(new Sample(Datastore.allocateId("Sample")));
+        real.add(new Sample(Datastore.allocateId("Sample")));
+
+        assertIdsEqual(expected, real);
+    }
+
+    class Sample implements HasId {
+        private Key id;
+
+        public Sample(Key id) {
+            this.id = id;
+        }
+
+        @Override
+        public Key getId() {
+            return id;
+        }
+
+        public void setId(Key id) {
+            this.id = id;
+        }
+    }
+}

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/dao/common/OrganizationMemberDaoTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/dao/common/OrganizationMemberDaoTest.java
@@ -13,7 +13,9 @@ import org.slim3.datastore.Datastore;
 import java.util.Arrays;
 import java.util.List;
 
-import static junit.framework.TestCase.*;
+import static com.jasify.schedule.appengine.AssertionHelper.assertIdsEqual;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertNotNull;
 
 public class OrganizationMemberDaoTest {
     private OrganizationMemberDao dao;
@@ -52,9 +54,7 @@ public class OrganizationMemberDaoTest {
             List<OrganizationMember> results = dao.byUserId(key);
             assertNotNull(results);
             assertEquals(2, results.size());
-
-            assertTrue(member1.getId().equals(results.get(0).getId()) || member3.getId().equals(results.get(0).getId()));
-            assertTrue(member1.getId().equals(results.get(1).getId()) || member3.getId().equals(results.get(1).getId()));
+            assertIdsEqual(Arrays.asList(member1, member3), results);
         }
     }
 }

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/common/OrganizationServiceTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/model/common/OrganizationServiceTest.java
@@ -18,8 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.*;
 
 public class OrganizationServiceTest {

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/JasifyEndpointNotMockedTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/JasifyEndpointNotMockedTest.java
@@ -114,27 +114,13 @@ public class JasifyEndpointNotMockedTest {
 
     @Test(expected = ForbiddenException.class)
     public void mustBeAdminOrOrgMemberThrowsForbiddenException() throws NotFoundException, UnauthorizedException, ForbiddenException {
-        JasifyEndpoint.mustBeAdminOrOrgMember(newCaller(1), new JasifyEndpoint.OrgMemberChecker(null) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                return null;
-            }
-            @Override
-            public boolean isOrgMember(long userId) throws EntityNotFoundException {
-                return false;
-            }
-        });
+        JasifyEndpoint.mustBeAdminOrOrgMember(newCaller(1), OrgMemberChecker.createFalse());
     }
 
 
     @Test(expected = NotFoundException.class)
     public void mustBeAdminOrOrgMemberThrowsNotFoundException() throws NotFoundException, UnauthorizedException, ForbiddenException {
-        JasifyEndpoint.mustBeAdminOrOrgMember(newOrgMemberCaller(1), new JasifyEndpoint.OrgMemberChecker(null) {
-            @Override
-            Organization getOrganization() throws EntityNotFoundException {
-                throw new EntityNotFoundException();
-            }
-        });
+        JasifyEndpoint.mustBeAdminOrOrgMember(newOrgMemberCaller(1), OrgMemberChecker.createNotFound());
     }
 
     @Test(expected = NotFoundException.class)

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/OrganizationEndpointTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/OrganizationEndpointTest.java
@@ -23,11 +23,9 @@ import org.slim3.datastore.Datastore;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.jasify.schedule.appengine.spi.JasifyEndpointTest.newAdminCaller;
-import static com.jasify.schedule.appengine.spi.JasifyEndpointTest.newCaller;
-import static com.jasify.schedule.appengine.spi.JasifyEndpointTest.newOrgMemberCaller;
+import static com.jasify.schedule.appengine.spi.JasifyEndpointTest.*;
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertTrue;
 import static org.easymock.EasyMock.*;
 
 public class OrganizationEndpointTest {
@@ -93,7 +91,7 @@ public class OrganizationEndpointTest {
         testOrganizationServiceFactory.replay();
         endpoint.addOrganization(null, null);
     }
-    
+
     @Test(expected = ForbiddenException.class)
     public void testAddOrganizationNotAdmin() throws Exception {
         testOrganizationServiceFactory.replay();
@@ -111,7 +109,7 @@ public class OrganizationEndpointTest {
         testOrganizationServiceFactory.replay();
         endpoint.removeOrganization(null, null);
     }
-    
+
     @Test(expected = ForbiddenException.class)
     public void testGetOrganizationNotAdmin() throws Exception {
         testOrganizationServiceFactory.replay();
@@ -123,7 +121,7 @@ public class OrganizationEndpointTest {
         testOrganizationServiceFactory.replay();
         endpoint.addUserToOrganization(null, null, null);
     }
-    
+
     @Test(expected = ForbiddenException.class)
     public void testAddUserToOrganizationNotAdmin() throws Exception {
         testOrganizationServiceFactory.replay();
@@ -322,14 +320,25 @@ public class OrganizationEndpointTest {
 
     @Test
     public void testGetOrganizationsForUser() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        JasifyEndpointUser caller = newOrgMemberCaller(55);
-        ArrayList<Organization> expected = new ArrayList<>();
-        expect(service.getOrganizationsForUser(caller.getUserId())).andReturn(expected);
         testOrganizationServiceFactory.replay(); //recording finished
+
+        Organization o1 = new Organization("Org1");
+        Organization o2 = new Organization("Org2");
+        Organization o3 = new Organization("Org3");
+        User user = new User("user1");
+
+        Datastore.put(o1, o2, o3, user);
+
+        OrganizationMember om1 = new OrganizationMember(o1, user);
+        OrganizationMember om3 = new OrganizationMember(o3, user);
+
+        Datastore.put(om1, om3);
+
+        JasifyEndpointUser caller = newOrgMemberCaller(user.getId().getId());
         List<Organization> organizations = endpoint.getOrganizations(caller);
-        // I use == here since I know the method returns it directly
-        assertNotNull(organizations == expected);
+        assertEquals(2, organizations.size());
+        assertTrue(organizations.get(0).getId().equals(o1.getId()) || organizations.get(0).getId().equals(o3.getId()));
+        assertTrue(organizations.get(1).getId().equals(o1.getId()) || organizations.get(1).getId().equals(o3.getId()));
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/OrganizationEndpointTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/OrganizationEndpointTest.java
@@ -223,17 +223,6 @@ public class OrganizationEndpointTest {
     }
 
     @Test(expected = NotFoundException.class)
-    public void testGetOrganizationNotFound() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        Key key = Datastore.allocateId(Organization.class);
-        service.getOrganization(key);
-        expectLastCall().andThrow(new EntityNotFoundException());
-        testOrganizationServiceFactory.replay();
-        endpoint.getOrganization(newAdminCaller(55), key);
-    }
-
-
-    @Test(expected = NotFoundException.class)
     public void testUpdateOrganizationNotFoundViaEntityNotFoundException() throws Exception {
         OrganizationService service = OrganizationServiceFactory.getOrganizationService();
         Key key = Datastore.allocateId(Organization.class);
@@ -266,38 +255,6 @@ public class OrganizationEndpointTest {
         endpoint.updateOrganization(newAdminCaller(55), key, organization);
     }
 
-    @Test(expected = NotFoundException.class)
-    public void testAddOrganizationNotFoundViaEntityNotFoundException() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        Organization organization = new Organization();
-        Key key = Datastore.allocateId(Organization.class);
-        expect(service.addOrganization(organization)).andReturn(key);
-        service.getOrganization(key);
-        expectLastCall().andThrow(new EntityNotFoundException());
-        testOrganizationServiceFactory.replay();
-        endpoint.addOrganization(newAdminCaller(55), organization);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testAddOrganizationNotFoundViaFieldValueException() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        Organization organization = new Organization();
-        service.addOrganization(organization);
-        expectLastCall().andThrow(new FieldValueException(null));
-        testOrganizationServiceFactory.replay();
-        endpoint.addOrganization(newAdminCaller(55), organization);
-    }
-
-    @Test(expected = BadRequestException.class)
-    public void testAddOrganizationNotFoundViaUniqueConstraintException() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        Organization organization = new Organization();
-        service.addOrganization(organization);
-        expectLastCall().andThrow(new UniqueConstraintException(null));
-        testOrganizationServiceFactory.replay();
-        endpoint.addOrganization(newAdminCaller(55), organization);
-    }
-
     @Test
     public void testUpdateOrganization() throws Exception {
         OrganizationService service = OrganizationServiceFactory.getOrganizationService();
@@ -316,50 +273,6 @@ public class OrganizationEndpointTest {
 
         Organization result = endpoint.updateOrganization(newAdminCaller(55), key, organization);
         assertEquals(result, organization);
-    }
-
-    @Test
-    public void testGetOrganizationsForUser() throws Exception {
-        testOrganizationServiceFactory.replay(); //recording finished
-
-        Organization o1 = new Organization("Org1");
-        Organization o2 = new Organization("Org2");
-        Organization o3 = new Organization("Org3");
-        User user = new User("user1");
-
-        Datastore.put(o1, o2, o3, user);
-
-        OrganizationMember om1 = new OrganizationMember(o1, user);
-        OrganizationMember om3 = new OrganizationMember(o3, user);
-
-        Datastore.put(om1, om3);
-
-        JasifyEndpointUser caller = newOrgMemberCaller(user.getId().getId());
-        List<Organization> organizations = endpoint.getOrganizations(caller);
-        assertEquals(2, organizations.size());
-        assertTrue(organizations.get(0).getId().equals(o1.getId()) || organizations.get(0).getId().equals(o3.getId()));
-        assertTrue(organizations.get(1).getId().equals(o1.getId()) || organizations.get(1).getId().equals(o3.getId()));
-    }
-
-    @Test
-    public void testGetOrganization() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        Organization organization = new Organization();
-        expect(service.getOrganization(organization.getId())).andReturn(organization);
-        testOrganizationServiceFactory.replay();
-        Organization result = endpoint.getOrganization(newAdminCaller(55), organization.getId());
-        assertEquals(organization, result);
-    }
-
-    @Test
-    public void testAddOrganization() throws Exception {
-        OrganizationService service = OrganizationServiceFactory.getOrganizationService();
-        Organization organization = new Organization();
-        expect(service.addOrganization(organization)).andReturn(organization.getId());
-        expect(service.getOrganization(organization.getId())).andReturn(organization);
-        testOrganizationServiceFactory.replay();
-        Organization result = endpoint.addOrganization(newAdminCaller(55), organization);
-        assertEquals(organization, result);
     }
 
     @Test

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/transform/JasOrganizationTransformerTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/transform/JasOrganizationTransformerTest.java
@@ -14,8 +14,8 @@ import org.slim3.datastore.Datastore;
 import java.util.Arrays;
 import java.util.HashSet;
 
-import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
 
 public class JasOrganizationTransformerTest {
     private JasOrganizationTransformer transformer = new JasOrganizationTransformer();


### PR DESCRIPTION
# OrganizationEndpoint 

 * getOrganization is dao based
 * addOrganization **example** on [how to use dao with transaction](https://github.com/krico/jas/commit/3ca748af2c3ac9cfc487b9e160b1101c53e8e747?diff=unified#diff-7d0595e0a86524df55e8412c924bd840R85)
 * OrgMemberChecker modified to use OrgDao and is now based on [Flyweight pattern](http://en.wikipedia.org/wiki/Flyweight_pattern)