### PR TITLE
Auth restore no exception

### DIFF
--- a/schedule/schedule-appengine/src/main/client/jasify/booking-via-jasify/booking-via-jasify.js
+++ b/schedule/schedule-appengine/src/main/client/jasify/booking-via-jasify/booking-via-jasify.js
@@ -276,7 +276,7 @@
 
                         jasDialogs.ok('Checkout complete!', 'Thanks!', function () {
                             $timeout(function () {
-                                $location.path('/done')
+                                $location.path('/done');
                             }, 500);
                         }, true, 'success');
 

--- a/schedule/schedule-appengine/src/main/client/jasify/services/auth.service.js
+++ b/schedule/schedule-appengine/src/main/client/jasify/services/auth.service.js
@@ -97,7 +97,17 @@
             } else {
                 $log.debug("Restoring session...");
                 p = Endpoint.jasify(function (jasify) {
-                    return jasify.auth.restore();
+                    return jasify.auth.restore().then(function (res) {
+
+                            if (res.result && res.result.failed) {
+                                var reason = res.result.failureReason || 'No message';
+                                return $q.reject({status: 401, statusText: reason});
+                            }
+                            return $q.when(res);
+                        },
+                        function (res) {
+                            return $q.reject(res);
+                        });
                 });
             }
 

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/AuthEndpoint.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/AuthEndpoint.java
@@ -124,7 +124,8 @@ public class AuthEndpoint {
             return new JasLoginResponse(user, userSession);
         }
 
-        throw new UnauthorizedException("No session present");
+        log.info("Restore failed");
+        return new JasLoginResponse(true, "No session present");
     }
 
     @ApiMethod(name = "auth.logout", path = "auth/logout", httpMethod = ApiMethod.HttpMethod.POST)

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/dm/JasLoginResponse.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/spi/dm/JasLoginResponse.java
@@ -9,6 +9,17 @@ import com.jasify.schedule.appengine.util.KeyUtil;
  * @since 01/01/15.
  */
 public class JasLoginResponse implements JasEndpointEntity {
+
+    /**
+     * When this is true, the only other field available is {@link #failureReason}
+     */
+    private boolean failed;
+
+    /**
+     * This is only set if {@link #failed} is true
+     */
+    private String failureReason;
+
     private String sessionId; /* Session id */
     private String userId;
     private String name;
@@ -19,6 +30,11 @@ public class JasLoginResponse implements JasEndpointEntity {
     public JasLoginResponse() {
     }
 
+    public JasLoginResponse(boolean failed, String failureReason) {
+        this.failed = failed;
+        this.failureReason = failureReason;
+    }
+
     public JasLoginResponse(User user, UserSession userSession) {
         setUserId(KeyUtil.keyToString(user.getId()));
         setSessionId(userSession.getSessionId());
@@ -26,6 +42,22 @@ public class JasLoginResponse implements JasEndpointEntity {
         setAdmin(user.isAdmin());
         setUser(user);
         setOrgMember(userSession.isOrgMember());
+    }
+
+    public boolean isFailed() {
+        return failed;
+    }
+
+    public void setFailed(boolean failed) {
+        this.failed = failed;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
     }
 
     public User getUser() {

--- a/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/AuthEndpointTest.java
+++ b/schedule/schedule-appengine/src/test/java/com/jasify/schedule/appengine/spi/AuthEndpointTest.java
@@ -39,13 +39,13 @@ public class AuthEndpointTest {
     private TestUserServiceFactory testUserServiceFactory = new TestUserServiceFactory();
     private TestOAuth2ServiceFactory testOAuth2ServiceFactory = new TestOAuth2ServiceFactory();
 
-    private AuthEndpoint endpoint = new AuthEndpoint();
+    private AuthEndpoint endpoint;
 
     @Before
     public void datastore() {
         TestHelper.initializeDatastore();
         testUserServiceFactory.setUp();
-
+        endpoint = new AuthEndpoint();
     }
 
     @After
@@ -275,10 +275,12 @@ public class AuthEndpointTest {
         endpoint.recoverPassword(request);
     }
 
-    @Test(expected = UnauthorizedException.class)
+    @Test
     public void testRestoreUnauthorized() throws Exception {
         testUserServiceFactory.replay();
-        endpoint.restore();
+        JasLoginResponse restore = endpoint.restore();
+        assertNotNull(restore);
+        assertTrue(restore.isFailed());
     }
 
     @Test
@@ -297,6 +299,7 @@ public class AuthEndpointTest {
 
         JasLoginResponse response = endpoint.restore();
         assertNotNull(response);
+        assertFalse(response.isFailed());
         assertEquals(user, response.getUser());
     }
 }


### PR DESCRIPTION
AuthEndpoint.restore no longer throws UnauthorizedException when there is no session present.  Instead, it sets `failed=true` in the response and this is handled as a reject on the frontend javascript.