### PR TITLE
Added subscription history

### DIFF
--- a/schedule/schedule-appengine/src/main/client/jasify/admin/history/admin-histories.html
+++ b/schedule/schedule-appengine/src/main/client/jasify/admin/history/admin-histories.html
@@ -21,7 +21,7 @@
                         </div>
                     </div>
                 </div>
-                <div class="col-sm-6 col-lg-3">
+                <div class="col-sm-6 col-lg-4">
                     <div class="actions btn-group btn-block">
                         <div class="dropdown btn-group btn-block">
                             <button type="button" class="btn btn-default btn-block dropdown-toggle"

--- a/schedule/schedule-appengine/src/main/client/jasify/directives/history/history-icon.directive.js
+++ b/schedule/schedule-appengine/src/main/client/jasify/directives/history/history-icon.directive.js
@@ -15,7 +15,11 @@
             PasswordRecovered: ['ion-ios-unlocked'],
             AccountCreated: ['mdi', 'mdi-person'],
             AccountCreationFailed: ['glyphicon', 'glyphicon-remove-circle'],
-            Logout: ['ion-android-exit']
+            Logout: ['ion-android-exit'],
+            SubscriptionCreated: ['glyphicon', 'glyphicon glyphicon-ok'],
+            SubscriptionCreationFailed: ['glyphicon', 'glyphicon-remove-circle'],
+            SubscriptionCancelled: ['glyphicon', 'glyphicon glyphicon-remove'],
+            SubscriptionCancellationFailed: ['glyphicon', 'glyphicon-remove-circle']
         };
         var defaultTextClass = [];
         var textClassMap = {
@@ -23,7 +27,11 @@
             AccountCreationFailed: ['text-danger'],
             PasswordForgottenFailed: ['text-danger'],
             PasswordRecovered: ['text-success'],
-            LoginFailed: ['text-danger']
+            LoginFailed: ['text-danger'],
+            SubscriptionCreated: ['text-success'],
+            SubscriptionCreationFailed: ['text-danger'],
+            SubscriptionCancelled: ['text-success'],
+            SubscriptionCancellationFailed: ['text-danger']
         };
         return {
             restrict: 'E',

--- a/schedule/schedule-appengine/src/main/i18n/locale-en.json
+++ b/schedule/schedule-appengine/src/main/i18n/locale-en.json
@@ -229,5 +229,9 @@
   "HT_PasswordChanged": "Password Changed",
   "HT_PasswordForgotten": "Recover Password",
   "HT_PasswordForgottenFailed": "Recover Password Failed",
-  "HT_PasswordRecovered": "Password Recovered"
+  "HT_PasswordRecovered": "Password Recovered",
+  "HT_SubscriptionCreated": "Subscription Created",
+  "HT_SubscriptionCreationFailed": "Subscription Creation Failed",
+  "HT_SubscriptionCancelled": "Subscription Cancelled",
+  "HT_SubscriptionCancellationFailed": "Subscription Cancellation Failed"
 }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/meta/history/SubscriptionHistoryMeta.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/meta/history/SubscriptionHistoryMeta.java
@@ -1,0 +1,185 @@
+package com.jasify.schedule.appengine.meta.history;
+
+//@javax.annotation.Generated(value = { "slim3-gen", "@VERSION@" })
+
+/** */
+public final class SubscriptionHistoryMeta extends org.slim3.datastore.ModelMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory> {
+
+    /** */
+    public final org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, com.google.appengine.api.datastore.Key> subscriptionId = new org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, com.google.appengine.api.datastore.Key>(this, "subscriptionId", "subscriptionId", com.google.appengine.api.datastore.Key.class);
+
+    /** */
+    public final org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, com.google.appengine.api.datastore.Key> id = new org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, com.google.appengine.api.datastore.Key>(this, "__key__", "id", com.google.appengine.api.datastore.Key.class);
+
+    /** */
+    public final org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, java.util.Date> created = new org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, java.util.Date>(this, "created", "created", java.util.Date.class);
+
+    /** */
+    public final org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, com.jasify.schedule.appengine.model.history.HistoryTypeEnum> type = new org.slim3.datastore.CoreAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, com.jasify.schedule.appengine.model.history.HistoryTypeEnum>(this, "type", "type", com.jasify.schedule.appengine.model.history.HistoryTypeEnum.class);
+
+    /** */
+    public final org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory> description = new org.slim3.datastore.StringAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory>(this, "description", "description");
+
+    /** */
+    public final org.slim3.datastore.ModelRefAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, org.slim3.datastore.ModelRef<com.jasify.schedule.appengine.model.users.User>, com.jasify.schedule.appengine.model.users.User> currentUserRef = new org.slim3.datastore.ModelRefAttributeMeta<com.jasify.schedule.appengine.model.history.SubscriptionHistory, org.slim3.datastore.ModelRef<com.jasify.schedule.appengine.model.users.User>, com.jasify.schedule.appengine.model.users.User>(this, "currentUserRef", "currentUserRef", org.slim3.datastore.ModelRef.class, com.jasify.schedule.appengine.model.users.User.class);
+
+    private static final org.slim3.datastore.CreationDate slim3_createdAttributeListener = new org.slim3.datastore.CreationDate();
+
+    private static final SubscriptionHistoryMeta slim3_singleton = new SubscriptionHistoryMeta();
+
+    /**
+     * @return the singleton
+     */
+    public static SubscriptionHistoryMeta get() {
+        return slim3_singleton;
+    }
+
+    /** */
+    public SubscriptionHistoryMeta() {
+        super("History", com.jasify.schedule.appengine.model.history.SubscriptionHistory.class, java.util.Arrays.asList("com.jasify.schedule.appengine.model.history.SubscriptionHistory"));
+    }
+
+    @Override
+    public com.jasify.schedule.appengine.model.history.SubscriptionHistory entityToModel(com.google.appengine.api.datastore.Entity entity) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory model = new com.jasify.schedule.appengine.model.history.SubscriptionHistory();
+        model.setSubscriptionId((com.google.appengine.api.datastore.Key) entity.getProperty("subscriptionId"));
+        model.setId(entity.getKey());
+        model.setCreated((java.util.Date) entity.getProperty("created"));
+        model.setType(stringToEnum(com.jasify.schedule.appengine.model.history.HistoryTypeEnum.class, (java.lang.String) entity.getProperty("type")));
+        model.setDescription((java.lang.String) entity.getProperty("description"));
+        if (model.getCurrentUserRef() == null) {
+            throw new NullPointerException("The property(currentUserRef) is null.");
+        }
+        model.getCurrentUserRef().setKey((com.google.appengine.api.datastore.Key) entity.getProperty("currentUserRef"));
+        return model;
+    }
+
+    @Override
+    public com.google.appengine.api.datastore.Entity modelToEntity(java.lang.Object model) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = (com.jasify.schedule.appengine.model.history.SubscriptionHistory) model;
+        com.google.appengine.api.datastore.Entity entity = null;
+        if (m.getId() != null) {
+            entity = new com.google.appengine.api.datastore.Entity(m.getId());
+        } else {
+            entity = new com.google.appengine.api.datastore.Entity(kind);
+        }
+        entity.setProperty("subscriptionId", m.getSubscriptionId());
+        entity.setProperty("created", m.getCreated());
+        entity.setProperty("type", enumToString(m.getType()));
+        entity.setProperty("description", m.getDescription());
+        if (m.getCurrentUserRef() == null) {
+            throw new NullPointerException("The property(currentUserRef) must not be null.");
+        }
+        entity.setProperty("currentUserRef", m.getCurrentUserRef().getKey());
+        entity.setProperty("slim3.classHierarchyList", classHierarchyList);
+        return entity;
+    }
+
+    @Override
+    protected com.google.appengine.api.datastore.Key getKey(Object model) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = (com.jasify.schedule.appengine.model.history.SubscriptionHistory) model;
+        return m.getId();
+    }
+
+    @Override
+    protected void setKey(Object model, com.google.appengine.api.datastore.Key key) {
+        validateKey(key);
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = (com.jasify.schedule.appengine.model.history.SubscriptionHistory) model;
+        m.setId(key);
+    }
+
+    @Override
+    protected long getVersion(Object model) {
+        throw new IllegalStateException("The version property of the model(com.jasify.schedule.appengine.model.history.SubscriptionHistory) is not defined.");
+    }
+
+    @Override
+    protected void assignKeyToModelRefIfNecessary(com.google.appengine.api.datastore.AsyncDatastoreService ds, java.lang.Object model) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = (com.jasify.schedule.appengine.model.history.SubscriptionHistory) model;
+        if (m.getCurrentUserRef() == null) {
+            throw new NullPointerException("The property(currentUserRef) must not be null.");
+        }
+        m.getCurrentUserRef().assignKeyIfNecessary(ds);
+    }
+
+    @Override
+    protected void incrementVersion(Object model) {
+    }
+
+    @Override
+    protected void prePut(Object model) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = (com.jasify.schedule.appengine.model.history.SubscriptionHistory) model;
+        m.setCreated(slim3_createdAttributeListener.prePut(m.getCreated()));
+    }
+
+    @Override
+    protected void postGet(Object model) {
+    }
+
+    @Override
+    public String getSchemaVersionName() {
+        return "slim3.schemaVersion";
+    }
+
+    @Override
+    public String getClassHierarchyListName() {
+        return "slim3.classHierarchyList";
+    }
+
+    @Override
+    protected boolean isCipherProperty(String propertyName) {
+        return false;
+    }
+
+    @Override
+    protected void modelToJson(org.slim3.datastore.json.JsonWriter writer, java.lang.Object model, int maxDepth, int currentDepth) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = (com.jasify.schedule.appengine.model.history.SubscriptionHistory) model;
+        writer.beginObject();
+        org.slim3.datastore.json.Default encoder0 = new org.slim3.datastore.json.Default();
+        if (m.getSubscriptionId() != null) {
+            writer.setNextPropertyName("subscriptionId");
+            encoder0.encode(writer, m.getSubscriptionId());
+        }
+        if (m.getId() != null) {
+            writer.setNextPropertyName("id");
+            encoder0.encode(writer, m.getId());
+        }
+        if (m.getCreated() != null) {
+            writer.setNextPropertyName("created");
+            encoder0.encode(writer, m.getCreated());
+        }
+        if (m.getType() != null) {
+            writer.setNextPropertyName("type");
+            encoder0.encode(writer, m.getType());
+        }
+        if (m.getDescription() != null) {
+            writer.setNextPropertyName("description");
+            encoder0.encode(writer, m.getDescription());
+        }
+        if (m.getCurrentUserRef() != null && m.getCurrentUserRef().getKey() != null) {
+            writer.setNextPropertyName("currentUserRef");
+            encoder0.encode(writer, m.getCurrentUserRef(), maxDepth, currentDepth);
+        }
+        writer.endObject();
+    }
+
+    @Override
+    protected com.jasify.schedule.appengine.model.history.SubscriptionHistory jsonToModel(org.slim3.datastore.json.JsonRootReader rootReader, int maxDepth, int currentDepth) {
+        com.jasify.schedule.appengine.model.history.SubscriptionHistory m = new com.jasify.schedule.appengine.model.history.SubscriptionHistory();
+        org.slim3.datastore.json.JsonReader reader = null;
+        org.slim3.datastore.json.Default decoder0 = new org.slim3.datastore.json.Default();
+        reader = rootReader.newObjectReader("subscriptionId");
+        m.setSubscriptionId(decoder0.decode(reader, m.getSubscriptionId()));
+        reader = rootReader.newObjectReader("id");
+        m.setId(decoder0.decode(reader, m.getId()));
+        reader = rootReader.newObjectReader("created");
+        m.setCreated(decoder0.decode(reader, m.getCreated()));
+        reader = rootReader.newObjectReader("type");
+        m.setType(decoder0.decode(reader, m.getType(), com.jasify.schedule.appengine.model.history.HistoryTypeEnum.class));
+        reader = rootReader.newObjectReader("description");
+        m.setDescription(decoder0.decode(reader, m.getDescription()));
+        reader = rootReader.newObjectReader("currentUserRef");
+        decoder0.decode(reader, m.getCurrentUserRef(), maxDepth, currentDepth);
+        return m;
+    }
+}

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/history/HistoryTypeEnum.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/history/HistoryTypeEnum.java
@@ -14,5 +14,9 @@ public enum HistoryTypeEnum {
     PasswordRecovered,
     AccountCreated,
     AccountCreationFailed,
+    SubscriptionCreated,
+    SubscriptionCreationFailed,
+    SubscriptionCancelled,
+    SubscriptionCancellationFailed,
     Message;
 }

--- a/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/history/SubscriptionHistory.java
+++ b/schedule/schedule-appengine/src/main/java/com/jasify/schedule/appengine/model/history/SubscriptionHistory.java
@@ -1,0 +1,28 @@
+package com.jasify.schedule.appengine.model.history;
+
+import com.google.appengine.api.datastore.Key;
+import org.slim3.datastore.Model;
+
+/**
+ * @author wszarmach
+ * @since 26/08/15.
+ */
+@Model
+public class SubscriptionHistory extends History {
+    private Key subscriptionId;
+
+    public SubscriptionHistory() {
+    }
+
+    public SubscriptionHistory(HistoryTypeEnum type) {
+        super(type);
+    }
+
+    public Key getSubscriptionId() {
+        return this.subscriptionId;
+    }
+
+    public void setSubscriptionId(Key subscriptionId) {
+        this.subscriptionId = subscriptionId;
+    }
+}


### PR DESCRIPTION
* SubscriptionCreated
* SubscriptionCreationFailed
* SubscriptionCancelled
* SubscriptionCancellationFailed

Note the following;
* Because we currently delete entities the SubscriptionCancelled is commented out
* The HistoryTypeEnum names are rather long. This is also reflected in the frontend. To fit Subscription Created I had to grow the History Event Type field. Any suggestions?
* The description field is UserId:UserName/ActivityId:ActivityName. Again alternate suggestions welcome?
![screen shot 2015-08-28 at 01 11 13](https://cloud.githubusercontent.com/assets/9398950/9535454/c6056c72-4d21-11e5-969c-a2252ea670d4.png)
